### PR TITLE
Add hybrid lexical + semantic query engine

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,47 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+dolt-access.lock
+
+# Runtime files
+bd.sock
+sync-state.json
+last-touched
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+.jsonl.lock
+sync_base.jsonl
+export-state/
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+daemon.lock
+daemon.log
+daemon-*.log.gz
+daemon.pid
+beads.base.jsonl
+beads.base.meta.json
+beads.left.jsonl
+beads.left.meta.json
+beads.right.jsonl
+beads.right.meta.json
+
+# NOTE: Do NOT add negation patterns (e.g., !issues.jsonl) here.
+# They would override fork protection in .git/info/exclude, allowing
+# contributors to accidentally commit upstream issue databases.
+# The JSONL files (issues.jsonl, interactions.jsonl) and config files
+# are tracked by git by default since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --status in_progress
+bd update <issue-id> --status done
+
+# Sync with git remote
+bd sync
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in `.beads/issues.jsonl` and synced like code
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Always in sync**: Auto-syncs with your commits
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Automatic sync with git commits
+- Branch-aware issue tracking
+- Intelligent JSONL merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,42 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: load from JSONL, write back after each command
+# When true, bd will use .beads/issues.jsonl as the source of truth
+# instead of the Dolt database
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Default actor for audit trails (overridden by BD_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct JSONL
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# Integration settings (access with 'bd config get/set')
+# These are stored in the database, not in this file:
+# - jira.url
+# - jira.project
+# - linear.url
+# - linear.api-key
+# - github.org
+# - github.repo

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+# bd-shim v1
+# bd-hooks-version: 0.55.1
+#
+# bd (beads) post-checkout hook - thin shim
+#
+# This shim delegates to 'bd hook post-checkout' which contains
+# the actual hook logic. This pattern ensures hook behavior is always
+# in sync with the installed bd version - no manual updates needed.
+#
+# The 'bd hook' command (singular) supports:
+# - Guard against frequent firing (only imports if JSONL changed)
+# - Per-worktree state tracking
+# - Dolt branch-then-merge pattern
+# - Hook chaining configuration
+
+# Check if bd is available
+if ! command -v bd >/dev/null 2>&1; then
+    # Silently skip - post-checkout is called frequently
+    exit 0
+fi
+
+exec bd hook post-checkout "$@"

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# bd-shim v1
+# bd-hooks-version: 0.55.1
+#
+# bd (beads) post-merge hook - thin shim
+#
+# This shim delegates to 'bd hook post-merge' which contains
+# the actual hook logic. This pattern ensures hook behavior is always
+# in sync with the installed bd version - no manual updates needed.
+#
+# The 'bd hook' command (singular) supports:
+# - Branch-then-merge pattern for Dolt (cell-level conflict resolution)
+# - Per-worktree state tracking
+# - Hook chaining configuration
+
+# Check if bd is available
+if ! command -v bd >/dev/null 2>&1; then
+    echo "Warning: bd command not found in PATH, skipping post-merge hook" >&2
+    echo "  Install bd: brew install beads" >&2
+    echo "  Or add bd to your PATH" >&2
+    exit 0
+fi
+
+exec bd hook post-merge "$@"

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+# bd-shim v2
+# bd-hooks-version: 0.55.1
+#
+# bd (beads) pre-commit hook — thin shim
+#
+# Delegates to 'bd hook pre-commit' which contains the actual hook logic.
+# This pattern ensures hook behavior is always in sync with the installed
+# bd version — no manual updates needed.
+#
+# The 'bd hook' command supports:
+# - Per-worktree export state tracking
+# - Dolt in-process export (no lock deadlocks)
+# - Sync-branch routing
+# - Hook chaining configuration
+
+# Check if bd is available
+if ! command -v bd >/dev/null 2>&1; then
+    echo "Warning: bd command not found in PATH, skipping pre-commit hook" >&2
+    echo "  Install bd: brew install beads" >&2
+    echo "  Or add bd to your PATH" >&2
+    exit 0
+fi
+
+exec bd hook pre-commit "$@"

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# bd-shim v1
+# bd-hooks-version: 0.55.1
+#
+# bd (beads) pre-push hook - thin shim
+#
+# This shim delegates to 'bd hooks run pre-push' which contains
+# the actual hook logic. This pattern ensures hook behavior is always
+# in sync with the installed bd version - no manual updates needed.
+
+# Check if bd is available
+if ! command -v bd >/dev/null 2>&1; then
+    echo "Warning: bd command not found in PATH, skipping pre-push hook" >&2
+    echo "  Install bd: brew install beads" >&2
+    echo "  Or add bd to your PATH" >&2
+    exit 0
+fi
+
+exec bd hooks run pre-push "$@"

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# bd-shim v1
+# bd-hooks-version: 0.48.0
+#
+# bd (beads) prepare-commit-msg hook - thin shim
+#
+# This shim delegates to 'bd hooks run prepare-commit-msg' which contains
+# the actual hook logic. This pattern ensures hook behavior is always
+# in sync with the installed bd version - no manual updates needed.
+#
+# Arguments:
+#   $1 = path to the commit message file
+#   $2 = source of commit message (message, template, merge, squash, commit)
+#   $3 = commit SHA-1 (if -c, -C, or --amend)
+
+# Check if bd is available
+if ! command -v bd >/dev/null 2>&1; then
+    echo "Warning: bd command not found in PATH, skipping prepare-commit-msg hook" >&2
+    echo "  Install bd: brew install beads" >&2
+    echo "  Or add bd to your PATH" >&2
+    exit 0
+fi
+
+exec bd hooks run prepare-commit-msg "$@"

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,6 @@
+{
+  "database": "dolt",
+  "jsonl_export": "issues.jsonl",
+  "backend": "dolt",
+  "dolt_database": "beads_McBrain"
+}

--- a/.claude/plans/2-add-query-engine.md
+++ b/.claude/plans/2-add-query-engine.md
@@ -1,0 +1,241 @@
+# Plan: Add Query Engine (Issue #2)
+
+## Context
+
+GitHub issue [#2 "Add query engine"](https://github.com/jbdamask/McBrain/issues/2) asks for a search/query engine so McBrain query performance stays stable as the knowledge base grows. Today the query procedure (defined in each vault's `CLAUDE.md`, executed by Claude through that vault's filesystem MCP) is:
+
+1. Read `wiki/index.md` to find relevant pages
+2. Read those pages
+3. Synthesize an answer with citations
+
+This degrades as the wiki grows because (a) `index.md` itself grows and starts taking real context to load, and (b) "find relevant pages" by skimming a flat catalog is fragile — Claude either over-reads or misses pages whose titles don't lexically match the question.
+
+McBrain ships as a Claude plugin marketplace whose only artifacts are Markdown skills + reference templates under `plugins/mcbrain/skills/`. There is no compiled code, no test runner, no typecheck. Each user's vault is a separate Markdown directory accessed via a per-vault filesystem MCP. Procedures (ingest / query / lint) are documented in the vault's `CLAUDE.md` and executed by Claude.
+
+## Locked Design Decisions
+
+The user has chosen the following architecture. The rest of this plan is written against these decisions; do not revisit them.
+
+1. **Hybrid lexical + semantic, both on by default.** Every vault gets both. Semantic is *not* opt-in — it's automatic.
+2. **Zero-touch setup.** The `mcbrain-setup` skill provisions everything: per-vault Python venv, packages, initial index. The user installs McBrain and "it just works."
+3. **Per-vault venv, shared model cache.** Python venv lives at `<vault>/.mcbrain/venv/`. The FastEmbed ONNX model weights live in FastEmbed's default cache (`~/.cache/fastembed/`) — shared across vaults so additional vaults are instant to set up and don't re-download the ~30 MB model.
+4. **Lexical engine: ripgrep** over `wiki/` (with a `grep -ri` fallback when `rg` isn't available). Stateless.
+5. **Semantic engine: FastEmbed (CPU ONNX) + sqlite-vec.** Index lives at `<vault>/.mcbrain/index.db`. Model: `BAAI/bge-small-en-v1.5` (384-dim, ~30 MB, fast on CPU).
+6. **Index scope: `wiki/` only.** `raw/` is intentionally excluded — it's source material that's already cited from wiki pages and would roughly double the index size.
+7. **Hybrid ranking: Reciprocal Rank Fusion (RRF).** Standard, well-studied, no tuning knobs.
+8. **New skill: `mcbrain-ops`.** Owns the indexing lifecycle (`query`, `index sync`, `index rebuild`, `index status`, `uninstall`). Called automatically by the `mcbrain` skill after any wiki edit, and at query time.
+9. **Chunking: per-page initially.** Each `wiki/*.md` file is one chunk. If pages routinely exceed ~1500 tokens, revisit and split on `##` headings — but keep first-cut simple.
+10. **Existing vaults upgrade in place.** When the user runs `mcbrain-ops` on a vault that has no `.mcbrain/` yet, it provisions the venv and builds the initial index. No vault is left behind.
+11. **McBrain never installs system-wide tools.** The only things McBrain creates or modifies on the user's machine live inside `<vault>/.mcbrain/` (per-vault venv, per-vault sqlite database, per-vault scripts) and inside FastEmbed's existing user-level cache (`~/.cache/fastembed/`, owned by the FastEmbed library, not by McBrain itself). McBrain *detects* required system prerequisites (`python3`, `rg`) and *surfaces platform-appropriate instructions* for the user to install them; it never invokes a system package manager (`brew`, `winget`, `apt`, `dnf`, etc.) on the user's behalf. This applies everywhere in the plan: any "install" verb the engineer encodes must mean "into a per-vault venv via `pip`," never "system-wide."
+12. **Cross-platform: macOS, Linux, Windows.** Implementation must work on all three. Detection logic should not assume a POSIX shell (Windows users may be in PowerShell, Git Bash, WSL, or cmd). Instructions surfaced to the user must be branched on detected OS.
+
+## Recommended Approach
+
+Three streams of work, in order. Each ends in a shippable state.
+
+### Stream 1 — `mcbrain-ops` skill (the engine)
+
+A new skill at `plugins/mcbrain/skills/mcbrain-ops/`. It owns all index operations and is the only place Python lives. Other skills delegate to it.
+
+**Public operations (what Claude invokes via this skill):**
+
+- `query "<text>" [--k 8]` — runs hybrid search, returns ranked list of `wiki/*.md` paths + scores + short excerpts as JSON to stdout.
+- `index sync` — incremental: detects added / changed / deleted wiki files via content hash, re-embeds only the deltas. Default after-edit path. Idempotent and fast (sub-second on no-op).
+- `index rebuild` — wipes the index and re-embeds everything. Used when the embedding model or schema changes, or on suspected corruption.
+- `index status` — prints doc count, last sync time, model name + dimension, index file size.
+- `migrate` — provisions `.mcbrain/` (venv + packages + initial index) on a vault that doesn't have it yet, AND patches the vault's `CLAUDE.md` to include the current query-engine procedures (`## Query engine` section, rewritten `## Operations → Query`, `index sync` hook in ingest/update procedures). Idempotent: re-running on a fully migrated vault is a no-op. Used by both the `mcbrain` skill (Stream 3 migration check) and as the underlying mechanism for `mcbrain-setup` Step 8.5.
+- `uninstall` — removes `<vault>/.mcbrain/`. Optionally cleans the FastEmbed shared cache if no other vault references it (see risks).
+
+**Internals:**
+
+- One small Python entry-point (`mcbrain_ops.py`) inside `<vault>/.mcbrain/bin/`, dispatched by subcommand.
+- Embedding via `fastembed.TextEmbedding(model_name="BAAI/bge-small-en-v1.5")`. Lets FastEmbed manage its own cache (no `cache_dir` override → shared behaviour for free).
+- Storage via `sqlite-vec`: one table for chunks (`id`, `path`, `content_hash`, `text`, `mtime`), one virtual `vec0` table for embeddings keyed by chunk id.
+- Lexical: shells out to `rg --type md --json` against `<vault>/wiki/`; on `rg` absence, falls back to `grep -ril --include='*.md'` and a Python BM25 pass over the candidate set.
+- Hybrid fusion: RRF over the lexical-rank list and the cosine-similarity-rank list. `score(d) = Σ 1/(k+rank_i(d))` with `k=60`. Top-K returned.
+- Single-process, synchronous. No daemon. Each call is a `python3 .mcbrain/bin/mcbrain_ops.py <subcommand>` invocation through `Bash`.
+
+**Files this skill owns:**
+
+- `plugins/mcbrain/skills/mcbrain-ops/SKILL.md` — describes when this skill triggers (mainly: invoked by other skills, but also directly when user asks to "rebuild the index", "check McBrain index status", etc.).
+- `plugins/mcbrain/skills/mcbrain-ops/README.md` — marketplace-facing description.
+- `plugins/mcbrain/skills/mcbrain-ops/references/requirements.txt` — `fastembed==<pinned>`, `sqlite-vec==<pinned>`. Versions resolved during implementation, not at plan time.
+- `plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py` — the dispatcher script. Single file, < 300 LoC. Subcommands: `query`, `index sync|rebuild|status`, `uninstall`.
+- `plugins/mcbrain/skills/mcbrain-ops/references/schema.sql` — initial sqlite schema (chunks table + vec0 virtual table).
+- `plugins/mcbrain/skills/mcbrain-ops/references/gitignore-snippet.md` — the lines added to `<vault>/.gitignore` for git-strategy vaults: `.mcbrain/venv/`, `.mcbrain/index.db`, `__pycache__/`. (`.mcbrain/bin/` *is* checked in so the script travels with the vault.)
+
+### Stream 2 — `mcbrain-setup` provisioning (zero-touch install)
+
+Update the existing setup skill so a fresh McBrain install ends with a working index.
+
+**New setup steps (additions, not replacements):**
+
+- **Step 5.5: Detect prerequisites (do not install).** McBrain never runs a system package manager itself (see Locked Decision 11). This step only *detects* what's available and *surfaces instructions* for the user to install missing pieces themselves.
+  - **Detect host OS** first (`uname -s` on POSIX; `$env:OS` / `ver` on Windows). Don't assume the shell — the detection step must work whether the user is in zsh, bash, PowerShell, Git Bash, WSL, or cmd.
+  - **Detect `python3`** by attempting to run it (`python3 --version`, falling back to `python --version` and parsing for `Python 3.x`). If absent: print a clear warning that semantic search will be unavailable until Python 3 is installed, and surface platform-appropriate guidance: macOS → suggest installing from python.org or via Homebrew if the user already has it; Linux → suggest the user's distro package manager (`apt install python3` / `dnf install python3` / etc.); Windows → suggest installing from python.org or via the Microsoft Store. **Do not block setup** — the vault still gets a working lexical-only path.
+  - **Detect `rg`** (`rg --version`). If absent: surface the same kind of platform-appropriate guidance and continue. The `grep` fallback (POSIX) / `Select-String` fallback (Windows PowerShell) handles the lexical path either way. **Do not block.**
+  - After surfacing instructions, prompt the user: "Install these now and let me know when ready, or proceed with the available subset?" If the user installs and confirms, re-run detection and continue. If they proceed without, record the limitation in the vault's `## Query engine` section so the user can fix it later.
+- **Step 8.5: Provision `.mcbrain/`.** Create `<vault>/.mcbrain/{venv,bin}/`. Create venv (`python3 -m venv .mcbrain/venv`). `pip install -r` the requirements from `mcbrain-ops/references/requirements.txt`. Copy `mcbrain_ops.py` and `schema.sql` from the `mcbrain-ops` skill's `references/` into `<vault>/.mcbrain/bin/`. Run `python3 .mcbrain/bin/mcbrain_ops.py index rebuild` to seed the empty index (no-op if `wiki/` is empty, which it will be for a fresh vault).
+- **Step 3 update (Git strategy):** `.gitignore` baked in by setup must now also include `.mcbrain/venv/`, `.mcbrain/index.db`, `__pycache__/`. (`bin/` stays in git so the script is reproducible.)
+
+**`claude-md-template.md` rewrites:**
+
+- `## Operations → Query` becomes: "Invoke the `mcbrain-ops` skill (`query "<text>"`). It returns a ranked list of wiki page paths + scores. Read the top 5–8 pages. Synthesize an answer with `[[wikilinks]]` citations. Offer to file the answer as a wiki page if it's worth keeping." `wiki/index.md` is no longer the retrieval mechanism — it stays for human browsing and `lint`.
+- `## Operations → Ingest from raw/`: append a final step "Invoke `mcbrain-ops` (`index sync`) so the new wiki page is searchable immediately."
+- `## Operations → Update existing wiki page`: same final step — `index sync`.
+- New `## Query engine` section, sibling of `## Backup`: records `mode: lexical+semantic`, `embedding_model: BAAI/bge-small-en-v1.5`, `embedding_dim: 384`, `index_path: .mcbrain/index.db`. The `mcbrain-ops` skill writes/updates this section during provisioning.
+
+### Stream 3 — Migration prompt in `mcbrain` (orchestration only)
+
+**Architectural principle (do not violate):** procedures (how to query, when to sync the index, how to ingest) live in the vault's `CLAUDE.md`, which is generated from `claude-md-template.md`. The `mcbrain` skill is a router — it defers to CLAUDE.md for everything procedural. **Stream 2 already places the query procedure and the post-edit `index sync` hooks into `claude-md-template.md`.** This stream must not duplicate or relocate any of that into the skill.
+
+The only thing the `mcbrain` skill is responsible for in this feature is a migration check: detecting vaults that pre-date the query engine and offering to upgrade them. That's a skill-level orchestration concern (the environment isn't ready yet) — distinct from any procedure CLAUDE.md describes.
+
+**`mcbrain/SKILL.md` changes:**
+
+- Add a "Migration check" subsection at the top of the skill's routing logic: when invoked against a vault, first verify the vault has `.mcbrain/` *and* that its `CLAUDE.md` contains a `## Query engine` section. If either is missing, the vault was set up before the query engine landed; offer the user a one-shot migration (delegate to `mcbrain-ops migrate`, which provisions `.mcbrain/` and updates `CLAUDE.md` to the current template). Once the user accepts and migration completes, defer to the (now-updated) `CLAUDE.md` as normal. Don't add anything else — query routing and post-edit syncing are CLAUDE.md procedures, not skill concerns.
+
+**`mcbrain-ops` skill addition (consequence of the migration design):**
+
+- Add `migrate` as a sixth subcommand on `mcbrain_ops.py`. It is the same logic as `mcbrain-setup` Step 8.5 (provision the venv, install packages, build initial index) plus a `CLAUDE.md` patcher that adds the `## Query engine` section, rewrites `## Operations → Query`, and appends the `index sync` step to existing ingest/update procedures. Idempotent: running it on an already-migrated vault is a no-op.
+
+**Why this design:** the user said "every time the wiki is updated, the index gets updated." That happens because `claude-md-template.md` (Stream 2) bakes the `index sync` step into every operation that writes the wiki — Claude reads CLAUDE.md, follows the procedure, runs `index sync` automatically. There's no daemon, no filesystem watcher, and no skill-level orchestration of that hook. If a user edits the vault outside Claude (e.g., directly in Obsidian), the next query — which itself runs through the CLAUDE.md procedure that calls `mcbrain-ops query`, which can opportunistically prelude with `index sync` — reconciles drift silently via content hashing.
+
+## Changes (file by file)
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/SKILL.md`
+
+Full new skill file. Frontmatter: `name: mcbrain-ops`, `description` triggers on "rebuild McBrain index", "check McBrain index", "McBrain query engine", and (most importantly) describes that this skill is invoked by the other McBrain skills as a subroutine. Body documents the five operations and their CLI shapes.
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/README.md`
+
+Marketplace-facing. Short. "Indexing and query engine that backs McBrain. Provisioned automatically by `mcbrain-setup`. Invoked automatically by `mcbrain` after wiki edits and at query time."
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/references/requirements.txt`
+
+Pinned versions of `fastembed` and `sqlite-vec`. Resolved during implementation against then-latest stable releases.
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py`
+
+The dispatcher. Single file, < 300 LoC, no dependencies beyond `fastembed`, `sqlite-vec`, and the standard library. Subcommands: `query`, `index sync`, `index rebuild`, `index status`, `uninstall`. Reads vault path from `--vault <path>` or `MCBRAIN_VAULT` env var. JSON output on stdout for `query` and `index status`; human-readable for the rest.
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/references/schema.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS chunks (
+  id INTEGER PRIMARY KEY,
+  path TEXT NOT NULL UNIQUE,
+  content_hash TEXT NOT NULL,
+  text TEXT NOT NULL,
+  mtime REAL NOT NULL
+);
+CREATE VIRTUAL TABLE IF NOT EXISTS chunk_vec USING vec0(
+  embedding float[384]
+);
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+```
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/references/gitignore-snippet.md`
+
+Lines for `<vault>/.gitignore`: `.mcbrain/venv/`, `.mcbrain/index.db`, `.mcbrain/index.db-*` (sqlite WAL/SHM), `__pycache__/`.
+
+### Modified: `plugins/mcbrain/skills/mcbrain-setup/SKILL.md`
+
+- New Step 5.5 (prereq detection) — see Stream 2 above.
+- New Step 8.5 (provision `.mcbrain/`) — see Stream 2 above.
+- Updated Step 3 (Git strategy gitignore additions).
+- Footer "Key operations to teach the user" expanded with the `mcbrain-ops` rebuild command for the rare case of needing a full reindex.
+
+### Modified: `plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md`
+
+- Rewrite `## Operations → Query`.
+- Append `index sync` step to `## Operations → Ingest from raw/` and to any "update wiki page" / "delete wiki page" procedures.
+- New `## Query engine` section template (filled in during provisioning).
+- `.gitignore` block updated for git strategy.
+
+### Modified: `plugins/mcbrain/skills/mcbrain/SKILL.md`
+
+- New "Migration check" subsection only. Detects pre-upgrade vaults (missing `.mcbrain/` or stale `CLAUDE.md`) and offers `mcbrain-ops migrate`. **No procedural changes here** — query routing and post-edit `index sync` are CLAUDE.md procedures (Stream 2), not skill concerns.
+
+### Modified: `README.md` (repo root)
+
+- New "Query engine" subsection under "Building Your Knowledgebase". Covers: hybrid lexical + semantic, automatic provisioning, where the index lives, how to rebuild manually if needed, what's in the shared cache and how to clear it.
+- Update dependency footprint section: now lists `python3` and `rg` (recommended) alongside Node.
+
+### Modified: `plugins/mcbrain/skills/mcbrain/README.md` and `plugins/mcbrain/skills/mcbrain-setup/README.md`
+
+- One-line mention that the query engine is built in and provisioned automatically.
+
+## Critical Files
+
+- `plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py` — *new*. The only piece of executable code McBrain ships. Every operation funnels through this script. Quality of this file determines the quality of the feature.
+- `plugins/mcbrain/skills/mcbrain-ops/SKILL.md` — *new*. Triggers and contracts for the operations.
+- `plugins/mcbrain/skills/mcbrain-setup/SKILL.md` — modified. Adds prereq detection and provisioning steps. Most user-visible change in the install flow.
+- `plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md` — modified. Defines the query procedure every vault's CLAUDE.md inherits.
+- `plugins/mcbrain/skills/mcbrain/SKILL.md` — modified. Wires auto-sync and migration prompts into day-to-day usage.
+
+## Dependencies & Ordering
+
+1. **Build `mcbrain-ops` first.** Stream 1. Standalone. Can be tested by manually creating `.mcbrain/` in a real vault, copying the script in, and exercising every subcommand. Verifying this in isolation before touching the other skills means we catch all the embedding / sqlite-vec / chunking bugs before they're spread across the wider system.
+2. **Wire `mcbrain-setup` to provision.** Stream 2. Depends on Stream 1 because it copies the script and requirements file from `mcbrain-ops/references/`. This is when fresh installs become end-to-end zero-touch.
+3. **Wire `mcbrain` for auto-sync and query routing.** Stream 3. Depends on Stream 1. Can land in parallel with Stream 2 — they touch different files.
+4. **Migration path for existing vaults.** Sub-feature of Stream 3. Same logic as Stream 2's Step 8.5, just triggered lazily.
+5. **Documentation pass.** README + skill READMEs, last.
+
+Single PR. The streams are interdependent enough that splitting them would create awkward "lexical-only" or "ops-without-callers" intermediate states. One coherent ship.
+
+## Risks & Open Questions
+
+- **Python availability.** This is the load-bearing assumption. If `python3` is missing the user can't get semantic. Mitigation: setup detects and instructs (`brew install python` / similar); falls back gracefully to lexical-only with a clear "install Python and re-run setup to enable semantic search" message. Worth thinking about whether to attempt `uv` / `pyenv` invocations as alternates — first cut: no, stick with system `python3`.
+- **`rg` availability.** Lower stakes — `grep` fallback is real. Setup recommends but doesn't require.
+- **First-vault model download.** ~30 MB FastEmbed download on first ever McBrain install. Surprises users on metered or air-gapped connections. Setup should announce this clearly before running it ("Downloading the embedding model (~30 MB, one-time, shared across all your McBrain vaults)…") and offer to skip — skipped vaults run lexical-only until first successful download.
+- **Shared cache lifecycle.** `~/.cache/fastembed/` is owned by FastEmbed, not by McBrain. If the user uninstalls every vault, ~30 MB stays orphaned. The `mcbrain-ops uninstall` subcommand can detect "no other vaults reference this cache" and clean it, but discovering "other vaults" is non-trivial without a registry. First cut: leave it, document it, add `mcbrain-ops cache clear` as an explicit command.
+- **Index drift outside Claude.** If the user edits a wiki page in Obsidian directly, the index goes stale. `index sync` uses content hashes (not just mtime), so the next call reconciles. The risk is the *next query* uses stale results because nothing triggered `sync` first. Mitigation: have `mcbrain-ops query` opportunistically run `sync` if it's been more than N seconds since the last sync, OR always run `sync` as a quick prelude to `query`. Hash-only sync on a small wiki is genuinely fast (sub-second when nothing changed), so prelude-sync is probably fine. Decide during implementation.
+- **Drive-synced vaults.** Google Drive may rewrite mtimes on sync. Hashing rather than relying on mtime sidesteps this.
+- **sqlite-vec install.** `sqlite-vec` ships as a loadable extension. On some platforms (notably system Python on macOS) the bundled sqlite3 isn't built with extension loading enabled. Mitigation: the `pip install sqlite-vec` package bundles a Python-loadable variant; verify on macOS / Linux / Windows during implementation. If a platform fails, fall back to numpy-based brute-force search (~50 LoC, fine up to ~10k chunks).
+- **Multi-language wikis.** `bge-small-en-v1.5` is English-tuned. Mostly fine; flag for future swap to a multilingual model if a user needs it.
+- **Concurrent writes.** Two Claude sessions editing the same vault could race on `index sync`. SQLite handles single-writer locking; one will block briefly and retry. Acceptable.
+- **Large pages.** Per-page chunking breaks for pages > ~1500 tokens (truncation, weaker embeddings). Plan revisits chunking on `##` boundaries if this becomes common.
+
+## Verification
+
+The plugin ships Markdown skills + reference scripts + one Python module. Acceptance is based on file existence, content shape, and end-to-end runnable checks. Per `AGENTS.md`, every Bead's acceptance criteria end with concrete behavioural checks (no typecheck step — this isn't a TypeScript project).
+
+**Static (file existence and shape):**
+
+- `plugins/mcbrain/skills/mcbrain-ops/{SKILL.md,README.md}` exist with valid YAML frontmatter.
+- `plugins/mcbrain/skills/mcbrain-ops/references/{requirements.txt,mcbrain_ops.py,schema.sql,gitignore-snippet.md}` all exist.
+- `mcbrain_ops.py` runs `--help` cleanly and lists all five subcommands.
+- `claude-md-template.md` no longer instructs Claude to "Read `wiki/index.md` to find relevant pages" as the *only* retrieval step. Its `## Operations → Query` section delegates to the `mcbrain-ops` skill.
+- `claude-md-template.md` contains a new `## Query engine` section.
+- `mcbrain-setup/SKILL.md` contains the new Step 5.5 (prereq detection) and Step 8.5 (provisioning).
+- `mcbrain/SKILL.md` contains "Post-edit hook", "Query routing", and "Migration prompt" subsections.
+
+**End-to-end (manual, on a real vault):**
+
+- *Fresh install end-to-end.* Run `mcbrain-setup` against a brand-new directory. Confirm `<vault>/.mcbrain/{venv,bin,index.db}` exist, `index status` reports 0 chunks, model name correct.
+- *Ingest → query loop.* Drop a markdown file into `raw/`, run an ingest. Confirm a wiki page appears, confirm `index sync` ran (chunks count incremented), then ask a paraphrased question that doesn't share keywords with the page title and confirm the page is in the top results.
+- *Hybrid wins.* Construct a query whose exact words appear in one wiki page (lexical winner) and whose meaning matches a different page (semantic winner). Confirm both appear in the top-K from `mcbrain-ops query`.
+- *Migration.* Take a vault that pre-dates this feature (no `.mcbrain/`). Open the `mcbrain` skill against it. Confirm the migration prompt fires and provisioning runs to completion. Repeat the ingest-to-query loop.
+- *No-Python fallback.* On a system without `python3`, run setup. Confirm setup completes, surfaces a clear warning, and the resulting vault's query path falls back to lexical-only without crashing.
+- *Backup respect.* On a git-strategy vault, `git status` after a full provision shows `.mcbrain/venv/` and `.mcbrain/index.db` ignored, while `.mcbrain/bin/` is tracked.
+- *Rebuild.* Run `mcbrain-ops index rebuild`; confirm chunk count matches `find wiki -name '*.md' | wc -l`.
+- *Uninstall.* Run `mcbrain-ops uninstall`; confirm `.mcbrain/` is gone and the rest of the vault is untouched.
+
+**Plugin install sanity:**
+
+- Running the marketplace install in Claude Desktop with the worktree as the source still loads the plugin without manifest errors.
+- The `mcbrain-ops` skill appears in the available-skills list and is callable directly.
+
+## Out of Scope (for this issue)
+
+- Cross-vault search (querying multiple McBrains in one shot).
+- A daemon / filesystem watcher for true real-time index sync.
+- Cross-encoder reranking — pure embedding similarity + RRF is enough at personal scale.
+- Web-UI / Obsidian-plugin search panel.
+- Switching the embedding model dynamically per-vault.
+- Multilingual model defaults.
+- Replacing the filesystem MCP with a custom McBrain MCP.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .DS_Store
 .env
+
+# Local test venv created by tests/README.md instructions
+.test-venv/
+
+# Python bytecode and pytest cache
+__pycache__/
+.pytest_cache/

--- a/.plan/2-add-query-engine.md
+++ b/.plan/2-add-query-engine.md
@@ -1,0 +1,241 @@
+# Plan: Add Query Engine (Issue #2)
+
+## Context
+
+GitHub issue [#2 "Add query engine"](https://github.com/jbdamask/McBrain/issues/2) asks for a search/query engine so McBrain query performance stays stable as the knowledge base grows. Today the query procedure (defined in each vault's `CLAUDE.md`, executed by Claude through that vault's filesystem MCP) is:
+
+1. Read `wiki/index.md` to find relevant pages
+2. Read those pages
+3. Synthesize an answer with citations
+
+This degrades as the wiki grows because (a) `index.md` itself grows and starts taking real context to load, and (b) "find relevant pages" by skimming a flat catalog is fragile — Claude either over-reads or misses pages whose titles don't lexically match the question.
+
+McBrain ships as a Claude plugin marketplace whose only artifacts are Markdown skills + reference templates under `plugins/mcbrain/skills/`. There is no compiled code, no test runner, no typecheck. Each user's vault is a separate Markdown directory accessed via a per-vault filesystem MCP. Procedures (ingest / query / lint) are documented in the vault's `CLAUDE.md` and executed by Claude.
+
+## Locked Design Decisions
+
+The user has chosen the following architecture. The rest of this plan is written against these decisions; do not revisit them.
+
+1. **Hybrid lexical + semantic, both on by default.** Every vault gets both. Semantic is *not* opt-in — it's automatic.
+2. **Zero-touch setup.** The `mcbrain-setup` skill provisions everything: per-vault Python venv, packages, initial index. The user installs McBrain and "it just works."
+3. **Per-vault venv, shared model cache.** Python venv lives at `<vault>/.mcbrain/venv/`. The FastEmbed ONNX model weights live in FastEmbed's default cache (`~/.cache/fastembed/`) — shared across vaults so additional vaults are instant to set up and don't re-download the ~30 MB model.
+4. **Lexical engine: ripgrep** over `wiki/` (with a `grep -ri` fallback when `rg` isn't available). Stateless.
+5. **Semantic engine: FastEmbed (CPU ONNX) + sqlite-vec.** Index lives at `<vault>/.mcbrain/index.db`. Model: `BAAI/bge-small-en-v1.5` (384-dim, ~30 MB, fast on CPU).
+6. **Index scope: `wiki/` only.** `raw/` is intentionally excluded — it's source material that's already cited from wiki pages and would roughly double the index size.
+7. **Hybrid ranking: Reciprocal Rank Fusion (RRF).** Standard, well-studied, no tuning knobs.
+8. **New skill: `mcbrain-ops`.** Owns the indexing lifecycle (`query`, `index sync`, `index rebuild`, `index status`, `uninstall`). Called automatically by the `mcbrain` skill after any wiki edit, and at query time.
+9. **Chunking: per-page initially.** Each `wiki/*.md` file is one chunk. If pages routinely exceed ~1500 tokens, revisit and split on `##` headings — but keep first-cut simple.
+10. **Existing vaults upgrade in place.** When the user runs `mcbrain-ops` on a vault that has no `.mcbrain/` yet, it provisions the venv and builds the initial index. No vault is left behind.
+11. **McBrain never installs system-wide tools.** The only things McBrain creates or modifies on the user's machine live inside `<vault>/.mcbrain/` (per-vault venv, per-vault sqlite database, per-vault scripts) and inside FastEmbed's existing user-level cache (`~/.cache/fastembed/`, owned by the FastEmbed library, not by McBrain itself). McBrain *detects* required system prerequisites (`python3`, `rg`) and *surfaces platform-appropriate instructions* for the user to install them; it never invokes a system package manager (`brew`, `winget`, `apt`, `dnf`, etc.) on the user's behalf. This applies everywhere in the plan: any "install" verb the engineer encodes must mean "into a per-vault venv via `pip`," never "system-wide."
+12. **Cross-platform: macOS, Linux, Windows.** Implementation must work on all three. Detection logic should not assume a POSIX shell (Windows users may be in PowerShell, Git Bash, WSL, or cmd). Instructions surfaced to the user must be branched on detected OS.
+
+## Recommended Approach
+
+Three streams of work, in order. Each ends in a shippable state.
+
+### Stream 1 — `mcbrain-ops` skill (the engine)
+
+A new skill at `plugins/mcbrain/skills/mcbrain-ops/`. It owns all index operations and is the only place Python lives. Other skills delegate to it.
+
+**Public operations (what Claude invokes via this skill):**
+
+- `query "<text>" [--k 8]` — runs hybrid search, returns ranked list of `wiki/*.md` paths + scores + short excerpts as JSON to stdout.
+- `index sync` — incremental: detects added / changed / deleted wiki files via content hash, re-embeds only the deltas. Default after-edit path. Idempotent and fast (sub-second on no-op).
+- `index rebuild` — wipes the index and re-embeds everything. Used when the embedding model or schema changes, or on suspected corruption.
+- `index status` — prints doc count, last sync time, model name + dimension, index file size.
+- `migrate` — provisions `.mcbrain/` (venv + packages + initial index) on a vault that doesn't have it yet, AND patches the vault's `CLAUDE.md` to include the current query-engine procedures (`## Query engine` section, rewritten `## Operations → Query`, `index sync` hook in ingest/update procedures). Idempotent: re-running on a fully migrated vault is a no-op. Used by both the `mcbrain` skill (Stream 3 migration check) and as the underlying mechanism for `mcbrain-setup` Step 8.5.
+- `uninstall` — removes `<vault>/.mcbrain/`. Optionally cleans the FastEmbed shared cache if no other vault references it (see risks).
+
+**Internals:**
+
+- One small Python entry-point (`mcbrain_ops.py`) inside `<vault>/.mcbrain/bin/`, dispatched by subcommand.
+- Embedding via `fastembed.TextEmbedding(model_name="BAAI/bge-small-en-v1.5")`. Lets FastEmbed manage its own cache (no `cache_dir` override → shared behaviour for free).
+- Storage via `sqlite-vec`: one table for chunks (`id`, `path`, `content_hash`, `text`, `mtime`), one virtual `vec0` table for embeddings keyed by chunk id.
+- Lexical: shells out to `rg --type md --json` against `<vault>/wiki/`; on `rg` absence, falls back to `grep -ril --include='*.md'` and a Python BM25 pass over the candidate set.
+- Hybrid fusion: RRF over the lexical-rank list and the cosine-similarity-rank list. `score(d) = Σ 1/(k+rank_i(d))` with `k=60`. Top-K returned.
+- Single-process, synchronous. No daemon. Each call is a `python3 .mcbrain/bin/mcbrain_ops.py <subcommand>` invocation through `Bash`.
+
+**Files this skill owns:**
+
+- `plugins/mcbrain/skills/mcbrain-ops/SKILL.md` — describes when this skill triggers (mainly: invoked by other skills, but also directly when user asks to "rebuild the index", "check McBrain index status", etc.).
+- `plugins/mcbrain/skills/mcbrain-ops/README.md` — marketplace-facing description.
+- `plugins/mcbrain/skills/mcbrain-ops/references/requirements.txt` — `fastembed==<pinned>`, `sqlite-vec==<pinned>`. Versions resolved during implementation, not at plan time.
+- `plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py` — the dispatcher script. Single file, < 300 LoC. Subcommands: `query`, `index sync|rebuild|status`, `uninstall`.
+- `plugins/mcbrain/skills/mcbrain-ops/references/schema.sql` — initial sqlite schema (chunks table + vec0 virtual table).
+- `plugins/mcbrain/skills/mcbrain-ops/references/gitignore-snippet.md` — the lines added to `<vault>/.gitignore` for git-strategy vaults: `.mcbrain/venv/`, `.mcbrain/index.db`, `__pycache__/`. (`.mcbrain/bin/` *is* checked in so the script travels with the vault.)
+
+### Stream 2 — `mcbrain-setup` provisioning (zero-touch install)
+
+Update the existing setup skill so a fresh McBrain install ends with a working index.
+
+**New setup steps (additions, not replacements):**
+
+- **Step 5.5: Detect prerequisites (do not install).** McBrain never runs a system package manager itself (see Locked Decision 11). This step only *detects* what's available and *surfaces instructions* for the user to install missing pieces themselves.
+  - **Detect host OS** first (`uname -s` on POSIX; `$env:OS` / `ver` on Windows). Don't assume the shell — the detection step must work whether the user is in zsh, bash, PowerShell, Git Bash, WSL, or cmd.
+  - **Detect `python3`** by attempting to run it (`python3 --version`, falling back to `python --version` and parsing for `Python 3.x`). If absent: print a clear warning that semantic search will be unavailable until Python 3 is installed, and surface platform-appropriate guidance: macOS → suggest installing from python.org or via Homebrew if the user already has it; Linux → suggest the user's distro package manager (`apt install python3` / `dnf install python3` / etc.); Windows → suggest installing from python.org or via the Microsoft Store. **Do not block setup** — the vault still gets a working lexical-only path.
+  - **Detect `rg`** (`rg --version`). If absent: surface the same kind of platform-appropriate guidance and continue. The `grep` fallback (POSIX) / `Select-String` fallback (Windows PowerShell) handles the lexical path either way. **Do not block.**
+  - After surfacing instructions, prompt the user: "Install these now and let me know when ready, or proceed with the available subset?" If the user installs and confirms, re-run detection and continue. If they proceed without, record the limitation in the vault's `## Query engine` section so the user can fix it later.
+- **Step 8.5: Provision `.mcbrain/`.** Create `<vault>/.mcbrain/{venv,bin}/`. Create venv (`python3 -m venv .mcbrain/venv`). `pip install -r` the requirements from `mcbrain-ops/references/requirements.txt`. Copy `mcbrain_ops.py` and `schema.sql` from the `mcbrain-ops` skill's `references/` into `<vault>/.mcbrain/bin/`. Run `python3 .mcbrain/bin/mcbrain_ops.py index rebuild` to seed the empty index (no-op if `wiki/` is empty, which it will be for a fresh vault).
+- **Step 3 update (Git strategy):** `.gitignore` baked in by setup must now also include `.mcbrain/venv/`, `.mcbrain/index.db`, `__pycache__/`. (`bin/` stays in git so the script is reproducible.)
+
+**`claude-md-template.md` rewrites:**
+
+- `## Operations → Query` becomes: "Invoke the `mcbrain-ops` skill (`query "<text>"`). It returns a ranked list of wiki page paths + scores. Read the top 5–8 pages. Synthesize an answer with `[[wikilinks]]` citations. Offer to file the answer as a wiki page if it's worth keeping." `wiki/index.md` is no longer the retrieval mechanism — it stays for human browsing and `lint`.
+- `## Operations → Ingest from raw/`: append a final step "Invoke `mcbrain-ops` (`index sync`) so the new wiki page is searchable immediately."
+- `## Operations → Update existing wiki page`: same final step — `index sync`.
+- New `## Query engine` section, sibling of `## Backup`: records `mode: lexical+semantic`, `embedding_model: BAAI/bge-small-en-v1.5`, `embedding_dim: 384`, `index_path: .mcbrain/index.db`. The `mcbrain-ops` skill writes/updates this section during provisioning.
+
+### Stream 3 — Migration prompt in `mcbrain` (orchestration only)
+
+**Architectural principle (do not violate):** procedures (how to query, when to sync the index, how to ingest) live in the vault's `CLAUDE.md`, which is generated from `claude-md-template.md`. The `mcbrain` skill is a router — it defers to CLAUDE.md for everything procedural. **Stream 2 already places the query procedure and the post-edit `index sync` hooks into `claude-md-template.md`.** This stream must not duplicate or relocate any of that into the skill.
+
+The only thing the `mcbrain` skill is responsible for in this feature is a migration check: detecting vaults that pre-date the query engine and offering to upgrade them. That's a skill-level orchestration concern (the environment isn't ready yet) — distinct from any procedure CLAUDE.md describes.
+
+**`mcbrain/SKILL.md` changes:**
+
+- Add a "Migration check" subsection at the top of the skill's routing logic: when invoked against a vault, first verify the vault has `.mcbrain/` *and* that its `CLAUDE.md` contains a `## Query engine` section. If either is missing, the vault was set up before the query engine landed; offer the user a one-shot migration (delegate to `mcbrain-ops migrate`, which provisions `.mcbrain/` and updates `CLAUDE.md` to the current template). Once the user accepts and migration completes, defer to the (now-updated) `CLAUDE.md` as normal. Don't add anything else — query routing and post-edit syncing are CLAUDE.md procedures, not skill concerns.
+
+**`mcbrain-ops` skill addition (consequence of the migration design):**
+
+- Add `migrate` as a sixth subcommand on `mcbrain_ops.py`. It is the same logic as `mcbrain-setup` Step 8.5 (provision the venv, install packages, build initial index) plus a `CLAUDE.md` patcher that adds the `## Query engine` section, rewrites `## Operations → Query`, and appends the `index sync` step to existing ingest/update procedures. Idempotent: running it on an already-migrated vault is a no-op.
+
+**Why this design:** the user said "every time the wiki is updated, the index gets updated." That happens because `claude-md-template.md` (Stream 2) bakes the `index sync` step into every operation that writes the wiki — Claude reads CLAUDE.md, follows the procedure, runs `index sync` automatically. There's no daemon, no filesystem watcher, and no skill-level orchestration of that hook. If a user edits the vault outside Claude (e.g., directly in Obsidian), the next query — which itself runs through the CLAUDE.md procedure that calls `mcbrain-ops query`, which can opportunistically prelude with `index sync` — reconciles drift silently via content hashing.
+
+## Changes (file by file)
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/SKILL.md`
+
+Full new skill file. Frontmatter: `name: mcbrain-ops`, `description` triggers on "rebuild McBrain index", "check McBrain index", "McBrain query engine", and (most importantly) describes that this skill is invoked by the other McBrain skills as a subroutine. Body documents the five operations and their CLI shapes.
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/README.md`
+
+Marketplace-facing. Short. "Indexing and query engine that backs McBrain. Provisioned automatically by `mcbrain-setup`. Invoked automatically by `mcbrain` after wiki edits and at query time."
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/references/requirements.txt`
+
+Pinned versions of `fastembed` and `sqlite-vec`. Resolved during implementation against then-latest stable releases.
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py`
+
+The dispatcher. Single file, < 300 LoC, no dependencies beyond `fastembed`, `sqlite-vec`, and the standard library. Subcommands: `query`, `index sync`, `index rebuild`, `index status`, `uninstall`. Reads vault path from `--vault <path>` or `MCBRAIN_VAULT` env var. JSON output on stdout for `query` and `index status`; human-readable for the rest.
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/references/schema.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS chunks (
+  id INTEGER PRIMARY KEY,
+  path TEXT NOT NULL UNIQUE,
+  content_hash TEXT NOT NULL,
+  text TEXT NOT NULL,
+  mtime REAL NOT NULL
+);
+CREATE VIRTUAL TABLE IF NOT EXISTS chunk_vec USING vec0(
+  embedding float[384]
+);
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+```
+
+### New: `plugins/mcbrain/skills/mcbrain-ops/references/gitignore-snippet.md`
+
+Lines for `<vault>/.gitignore`: `.mcbrain/venv/`, `.mcbrain/index.db`, `.mcbrain/index.db-*` (sqlite WAL/SHM), `__pycache__/`.
+
+### Modified: `plugins/mcbrain/skills/mcbrain-setup/SKILL.md`
+
+- New Step 5.5 (prereq detection) — see Stream 2 above.
+- New Step 8.5 (provision `.mcbrain/`) — see Stream 2 above.
+- Updated Step 3 (Git strategy gitignore additions).
+- Footer "Key operations to teach the user" expanded with the `mcbrain-ops` rebuild command for the rare case of needing a full reindex.
+
+### Modified: `plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md`
+
+- Rewrite `## Operations → Query`.
+- Append `index sync` step to `## Operations → Ingest from raw/` and to any "update wiki page" / "delete wiki page" procedures.
+- New `## Query engine` section template (filled in during provisioning).
+- `.gitignore` block updated for git strategy.
+
+### Modified: `plugins/mcbrain/skills/mcbrain/SKILL.md`
+
+- New "Migration check" subsection only. Detects pre-upgrade vaults (missing `.mcbrain/` or stale `CLAUDE.md`) and offers `mcbrain-ops migrate`. **No procedural changes here** — query routing and post-edit `index sync` are CLAUDE.md procedures (Stream 2), not skill concerns.
+
+### Modified: `README.md` (repo root)
+
+- New "Query engine" subsection under "Building Your Knowledgebase". Covers: hybrid lexical + semantic, automatic provisioning, where the index lives, how to rebuild manually if needed, what's in the shared cache and how to clear it.
+- Update dependency footprint section: now lists `python3` and `rg` (recommended) alongside Node.
+
+### Modified: `plugins/mcbrain/skills/mcbrain/README.md` and `plugins/mcbrain/skills/mcbrain-setup/README.md`
+
+- One-line mention that the query engine is built in and provisioned automatically.
+
+## Critical Files
+
+- `plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py` — *new*. The only piece of executable code McBrain ships. Every operation funnels through this script. Quality of this file determines the quality of the feature.
+- `plugins/mcbrain/skills/mcbrain-ops/SKILL.md` — *new*. Triggers and contracts for the operations.
+- `plugins/mcbrain/skills/mcbrain-setup/SKILL.md` — modified. Adds prereq detection and provisioning steps. Most user-visible change in the install flow.
+- `plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md` — modified. Defines the query procedure every vault's CLAUDE.md inherits.
+- `plugins/mcbrain/skills/mcbrain/SKILL.md` — modified. Wires auto-sync and migration prompts into day-to-day usage.
+
+## Dependencies & Ordering
+
+1. **Build `mcbrain-ops` first.** Stream 1. Standalone. Can be tested by manually creating `.mcbrain/` in a real vault, copying the script in, and exercising every subcommand. Verifying this in isolation before touching the other skills means we catch all the embedding / sqlite-vec / chunking bugs before they're spread across the wider system.
+2. **Wire `mcbrain-setup` to provision.** Stream 2. Depends on Stream 1 because it copies the script and requirements file from `mcbrain-ops/references/`. This is when fresh installs become end-to-end zero-touch.
+3. **Wire `mcbrain` for auto-sync and query routing.** Stream 3. Depends on Stream 1. Can land in parallel with Stream 2 — they touch different files.
+4. **Migration path for existing vaults.** Sub-feature of Stream 3. Same logic as Stream 2's Step 8.5, just triggered lazily.
+5. **Documentation pass.** README + skill READMEs, last.
+
+Single PR. The streams are interdependent enough that splitting them would create awkward "lexical-only" or "ops-without-callers" intermediate states. One coherent ship.
+
+## Risks & Open Questions
+
+- **Python availability.** This is the load-bearing assumption. If `python3` is missing the user can't get semantic. Mitigation: setup detects and instructs (`brew install python` / similar); falls back gracefully to lexical-only with a clear "install Python and re-run setup to enable semantic search" message. Worth thinking about whether to attempt `uv` / `pyenv` invocations as alternates — first cut: no, stick with system `python3`.
+- **`rg` availability.** Lower stakes — `grep` fallback is real. Setup recommends but doesn't require.
+- **First-vault model download.** ~30 MB FastEmbed download on first ever McBrain install. Surprises users on metered or air-gapped connections. Setup should announce this clearly before running it ("Downloading the embedding model (~30 MB, one-time, shared across all your McBrain vaults)…") and offer to skip — skipped vaults run lexical-only until first successful download.
+- **Shared cache lifecycle.** `~/.cache/fastembed/` is owned by FastEmbed, not by McBrain. If the user uninstalls every vault, ~30 MB stays orphaned. The `mcbrain-ops uninstall` subcommand can detect "no other vaults reference this cache" and clean it, but discovering "other vaults" is non-trivial without a registry. First cut: leave it, document it, add `mcbrain-ops cache clear` as an explicit command.
+- **Index drift outside Claude.** If the user edits a wiki page in Obsidian directly, the index goes stale. `index sync` uses content hashes (not just mtime), so the next call reconciles. The risk is the *next query* uses stale results because nothing triggered `sync` first. Mitigation: have `mcbrain-ops query` opportunistically run `sync` if it's been more than N seconds since the last sync, OR always run `sync` as a quick prelude to `query`. Hash-only sync on a small wiki is genuinely fast (sub-second when nothing changed), so prelude-sync is probably fine. Decide during implementation.
+- **Drive-synced vaults.** Google Drive may rewrite mtimes on sync. Hashing rather than relying on mtime sidesteps this.
+- **sqlite-vec install.** `sqlite-vec` ships as a loadable extension. On some platforms (notably system Python on macOS) the bundled sqlite3 isn't built with extension loading enabled. Mitigation: the `pip install sqlite-vec` package bundles a Python-loadable variant; verify on macOS / Linux / Windows during implementation. If a platform fails, fall back to numpy-based brute-force search (~50 LoC, fine up to ~10k chunks).
+- **Multi-language wikis.** `bge-small-en-v1.5` is English-tuned. Mostly fine; flag for future swap to a multilingual model if a user needs it.
+- **Concurrent writes.** Two Claude sessions editing the same vault could race on `index sync`. SQLite handles single-writer locking; one will block briefly and retry. Acceptable.
+- **Large pages.** Per-page chunking breaks for pages > ~1500 tokens (truncation, weaker embeddings). Plan revisits chunking on `##` boundaries if this becomes common.
+
+## Verification
+
+The plugin ships Markdown skills + reference scripts + one Python module. Acceptance is based on file existence, content shape, and end-to-end runnable checks. Per `AGENTS.md`, every Bead's acceptance criteria end with concrete behavioural checks (no typecheck step — this isn't a TypeScript project).
+
+**Static (file existence and shape):**
+
+- `plugins/mcbrain/skills/mcbrain-ops/{SKILL.md,README.md}` exist with valid YAML frontmatter.
+- `plugins/mcbrain/skills/mcbrain-ops/references/{requirements.txt,mcbrain_ops.py,schema.sql,gitignore-snippet.md}` all exist.
+- `mcbrain_ops.py` runs `--help` cleanly and lists all five subcommands.
+- `claude-md-template.md` no longer instructs Claude to "Read `wiki/index.md` to find relevant pages" as the *only* retrieval step. Its `## Operations → Query` section delegates to the `mcbrain-ops` skill.
+- `claude-md-template.md` contains a new `## Query engine` section.
+- `mcbrain-setup/SKILL.md` contains the new Step 5.5 (prereq detection) and Step 8.5 (provisioning).
+- `mcbrain/SKILL.md` contains "Post-edit hook", "Query routing", and "Migration prompt" subsections.
+
+**End-to-end (manual, on a real vault):**
+
+- *Fresh install end-to-end.* Run `mcbrain-setup` against a brand-new directory. Confirm `<vault>/.mcbrain/{venv,bin,index.db}` exist, `index status` reports 0 chunks, model name correct.
+- *Ingest → query loop.* Drop a markdown file into `raw/`, run an ingest. Confirm a wiki page appears, confirm `index sync` ran (chunks count incremented), then ask a paraphrased question that doesn't share keywords with the page title and confirm the page is in the top results.
+- *Hybrid wins.* Construct a query whose exact words appear in one wiki page (lexical winner) and whose meaning matches a different page (semantic winner). Confirm both appear in the top-K from `mcbrain-ops query`.
+- *Migration.* Take a vault that pre-dates this feature (no `.mcbrain/`). Open the `mcbrain` skill against it. Confirm the migration prompt fires and provisioning runs to completion. Repeat the ingest-to-query loop.
+- *No-Python fallback.* On a system without `python3`, run setup. Confirm setup completes, surfaces a clear warning, and the resulting vault's query path falls back to lexical-only without crashing.
+- *Backup respect.* On a git-strategy vault, `git status` after a full provision shows `.mcbrain/venv/` and `.mcbrain/index.db` ignored, while `.mcbrain/bin/` is tracked.
+- *Rebuild.* Run `mcbrain-ops index rebuild`; confirm chunk count matches `find wiki -name '*.md' | wc -l`.
+- *Uninstall.* Run `mcbrain-ops uninstall`; confirm `.mcbrain/` is gone and the rest of the vault is untouched.
+
+**Plugin install sanity:**
+
+- Running the marketplace install in Claude Desktop with the worktree as the source still loads the plugin without manifest errors.
+- The `mcbrain-ops` skill appears in the available-skills list and is callable directly.
+
+## Out of Scope (for this issue)
+
+- Cross-vault search (querying multiple McBrains in one shot).
+- A daemon / filesystem watcher for true real-time index sync.
+- Cross-encoder reranking — pure embedding similarity + RRF is enough at personal scale.
+- Web-UI / Obsidian-plugin search panel.
+- Switching the embedding model dynamically per-vault.
+- Multilingual model defaults.
+- Replacing the filesystem MCP with a custom McBrain MCP.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --status in_progress  # Claim work
+bd close <id>         # Complete work
+bd sync               # Sync with git
+```
+
+## Landing the Plane (Session Completion)
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd sync
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+

--- a/README.md
+++ b/README.md
@@ -43,15 +43,30 @@ Each time you have a conversation with Claude about the contents of your McBrain
 ![Ingest](./img/ingest.png)
 ![Notion](./img/notion-research-db.png)
 
+## Query engine
+
+Each McBrain vault ships with a built-in hybrid lexical + semantic query engine, provisioned automatically by `mcbrain-setup` (Step 8.5) and maintained by the `mcbrain-ops` skill. There's nothing to configure — `mcbrain-setup` creates a per-vault Python venv at `<vault>/.mcbrain/venv/`, installs the indexer dependencies, builds the initial search index, and patches your vault's `CLAUDE.md` to route queries through it.
+
+- **Lexical** uses ripgrep (`rg`) when available, with a `grep` / pure-Python fallback so the lexical path always works.
+- **Semantic** uses [FastEmbed](https://github.com/qdrant/fastembed)'s CPU-only ONNX embedding model (`BAAI/bge-small-en-v1.5`, 384 dims, ~30 MB). Queries like "cardiac event" still surface a page about *myocardial infarction* even though those words don't overlap.
+- **Hybrid ranking** uses Reciprocal Rank Fusion (RRF) over the two modalities.
+
+The embedding model lives in FastEmbed's shared cache (`~/.cache/fastembed/` on macOS/Linux, `%LOCALAPPDATA%\fastembed\` on Windows) so adding a second McBrain vault doesn't re-download it. Per-vault state — venv, index — lives at `<vault>/.mcbrain/` and is rebuildable from the wiki content. **No system-wide installs**: McBrain only detects whether `python3` and `rg` are available and surfaces install instructions if they aren't; everything else stays inside `<vault>/.mcbrain/`.
+
+Existing vaults that pre-date the engine get an automatic migration prompt the next time the `mcbrain` skill is invoked against them.
+
 ## Skills bundled in the plugin
 
-The `mcbrain` plugin contains four skills, all under [`plugins/mcbrain/skills/`](./plugins/mcbrain/skills):
+The `mcbrain` plugin contains five skills, all under [`plugins/mcbrain/skills/`](./plugins/mcbrain/skills):
 
 ### [`mcbrain-setup`](./plugins/mcbrain/skills/mcbrain-setup)
-One-shot setup skill that bootstraps McBrain end-to-end: names the vault, configures a backup strategy, scaffolds the directory structure, writes the filesystem MCP config block for Claude Desktop, walks through Obsidian and browser-extension setup, and verifies the install. Run this from Claude Cowork each time you want to make a new McBrain.
+One-shot setup skill that bootstraps McBrain end-to-end: names the vault, configures a backup strategy, scaffolds the directory structure, writes the filesystem MCP config block for Claude Desktop, **provisions the per-vault query engine**, walks through Obsidian and browser-extension setup, and verifies the install. Run this from Claude Cowork each time you want to make a new McBrain.
 
 ### [`mcbrain`](./plugins/mcbrain/skills/mcbrain)
 Day-to-day operating skill for McBrain. Handles ingesting sources into the vault, querying the wiki, filing synthesis pages, and linting. Supports multiple vaults (e.g. `mcbrain-finance`, `mcbrain-ai-science`) by mapping the user's request to the matching MCP filesystem server. Triggered by phrases like "ingest this", "save to mcbrain", "ask my brain", or any reference to the user's wiki / second brain.
+
+### [`mcbrain-ops`](./plugins/mcbrain/skills/mcbrain-ops)
+The query engine itself: a hybrid lexical + semantic search index over each vault's `wiki/`. Provisioned automatically by `mcbrain-setup` and called automatically by `mcbrain` after every wiki edit (to keep the index current) and at query time. You normally never invoke this directly — but it's the right skill if you ever need to rebuild the index, check its status, migrate an older vault, or remove the engine.
 
 ### [`notion-research-db`](./plugins/mcbrain/skills/notion-research-db)
 Creates a Notion database scoped to a research topic, with a fixed schema for tracking tasks (Task name, Status, Priority, Created date, Last updated date, Notes). After creation, registers the database name and URL back into the associated McBrain vault so the wiki knows where its companion tracker lives. Works with any Notion MCP connector — matches tools by capability rather than exact name.
@@ -78,6 +93,7 @@ McBrain/
 │       └── skills/
 │           ├── mcbrain-setup/
 │           ├── mcbrain/
+│           ├── mcbrain-ops/
 │           ├── notion-research-db/
 │           └── notion-research-runner/
 ├── README.md

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ McBrain/
 └── LICENSE
 ```
 
+## Running tests
+
+The query engine has a pytest suite under [`tests/`](./tests/) covering pure-function unit tests, the CLAUDE.md patcher, the index lifecycle (rebuild / sync / status), search behavior (lexical cascade, semantic recall, hybrid query, lazy text fetch), and a full end-to-end lifecycle through the script's CLI. Organized following Kent C. Dodds' [Testing Trophy](https://kentcdodds.com/blog/the-testing-trophy-and-testing-classifications): the bulk of the investment lives in integration tests with a real SQLite DB and a real FastEmbed embedder.
+
+```sh
+python3 -m venv .test-venv
+.test-venv/bin/pip install \
+  -r plugins/mcbrain/skills/mcbrain-ops/references/requirements.txt \
+  -r tests/requirements.txt
+
+.test-venv/bin/python -m pytest tests/ -v
+```
+
+First run downloads the FastEmbed model (~30 MB) into `~/.cache/fastembed/`. Subsequent runs reuse it and complete the full suite in a few seconds. See [`tests/README.md`](./tests/README.md) for layout and design notes.
+
 ## License
 
 See [LICENSE](./LICENSE).

--- a/plugins/mcbrain/skills/mcbrain-ops/README.md
+++ b/plugins/mcbrain/skills/mcbrain-ops/README.md
@@ -1,0 +1,22 @@
+# McBrain Ops
+
+Indexing and query engine that backs McBrain.
+
+Provisioned automatically by `mcbrain-setup` when a fresh vault is created. Invoked automatically by the `mcbrain` skill after wiki edits (to keep the index current) and at query time (to find the most relevant pages for a question).
+
+Hybrid search: lexical (ripgrep / grep fallback) + semantic (FastEmbed `BAAI/bge-small-en-v1.5` + sqlite-vec), fused via Reciprocal Rank Fusion. Per-vault index, shared model cache. Cross-platform: macOS, Linux, Windows.
+
+This is the only place Python lives in McBrain. Everything else is Markdown.
+
+## Operations
+
+| Subcommand | Purpose |
+|---|---|
+| `query "<text>"` | Hybrid lexical + semantic search; returns top-K wiki pages as JSON |
+| `index sync` | Incremental update — re-embed only changed/added/deleted wiki files |
+| `index rebuild` | Wipe and re-embed everything from scratch |
+| `index status` | Print doc count, last sync, model, index size |
+| `migrate` | Provision `.mcbrain/` on a vault that doesn't have one yet (idempotent) |
+| `uninstall` | Remove `.mcbrain/`; leave wiki/raw untouched |
+
+See `SKILL.md` for the full contract and `references/mcbrain_ops.py` for the implementation.

--- a/plugins/mcbrain/skills/mcbrain-ops/SKILL.md
+++ b/plugins/mcbrain/skills/mcbrain-ops/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: mcbrain-ops
+description: Indexing and query engine that backs McBrain. Use this skill when the user asks to "rebuild the McBrain index", "check McBrain index status", "uninstall the McBrain query engine", "migrate a vault to the McBrain query engine", or otherwise wants to manage the per-vault search index. This skill is also invoked as a subroutine by the `mcbrain` and `mcbrain-setup` skills — `mcbrain-setup` calls it during initial provisioning, `mcbrain` calls it at query time and after every wiki edit. The six subcommands are: query, index sync, index rebuild, index status, migrate, uninstall.
+---
+
+# McBrain Operations
+
+Manages the hybrid lexical + semantic search index for a McBrain vault. Every vault has its own per-vault Python venv at `<vault>/.mcbrain/venv/` and its own SQLite database at `<vault>/.mcbrain/index.db`. The embedding model itself (FastEmbed `BAAI/bge-small-en-v1.5`, 384 dims, ~30 MB ONNX) lives in FastEmbed's shared cache (`~/.cache/fastembed/`) so multiple vaults don't re-download it.
+
+This skill is the **only** place Python lives in McBrain. Everything else is Markdown skills + reference templates.
+
+## When to use this skill
+
+Direct triggers (the user asks for one of these):
+- "Rebuild the McBrain index" / "reindex McBrain" → `index rebuild`
+- "Check the McBrain index status" / "is the index healthy?" → `index status`
+- "Sync the McBrain index" / "the index is stale" → `index sync`
+- "Migrate this vault to the new query engine" / "this vault doesn't have an index" → `migrate`
+- "Uninstall the McBrain query engine" / "remove .mcbrain/ from this vault" → `uninstall`
+
+Indirect triggers (other skills invoke this one):
+- `mcbrain-setup` calls `migrate` during its Step 8.5 provisioning
+- `mcbrain` calls `query` whenever the user asks the wiki a question (per CLAUDE.md's `## Operations → Query`)
+- `mcbrain` calls `index sync` after every wiki write (per CLAUDE.md's ingest / update / delete procedures)
+- `mcbrain` calls `migrate` when it detects a vault with `wiki/` but no `.mcbrain/`
+
+## Subcommands
+
+All subcommands accept `--vault <path>` (or `MCBRAIN_VAULT` env var) to target the vault. JSON output for `query` and `index status`; human-readable for the rest. Exit code 0 on success, non-zero on error.
+
+### `query "<text>" [--k 8]`
+
+Runs hybrid search (lexical + semantic, fused via Reciprocal Rank Fusion at k=60). Returns the top `--k` (default 8) wiki pages as a JSON list to stdout, each entry containing the file path, fused score, and a short excerpt.
+
+```sh
+python3 <vault>/.mcbrain/bin/mcbrain_ops.py query "what does the wiki say about scaling laws" --vault <vault> --k 8
+```
+
+The skill-level call from CLAUDE.md / the `mcbrain` skill should pass the user's question verbatim, then read the returned page paths.
+
+### `index sync`
+
+Incremental index update. Walks `<vault>/wiki/`, compares each file's content hash against the stored hash in the index, and re-embeds only the deltas (added / modified / deleted). Idempotent and fast — sub-second on a no-op call. Default after-edit path; called automatically by the CLAUDE.md ingest/update procedures.
+
+### `index rebuild`
+
+Wipes the index and re-embeds every wiki file from scratch. Used when the embedding model or schema changes, or when corruption is suspected. Slow proportional to wiki size (FastEmbed encodes thousands of chunks per minute on a CPU laptop). Safe to run; non-destructive to wiki content.
+
+### `index status`
+
+Prints a JSON object with: `doc_count`, `last_sync` (ISO timestamp), `embedding_model`, `embedding_dim`, `index_path`, `index_size_bytes`. Used by the migration check in the `mcbrain` skill and by humans diagnosing index issues.
+
+### `migrate`
+
+Provisions a vault that doesn't have a working query engine yet. Idempotent — re-running on a fully migrated vault is a no-op. Steps:
+
+1. Create `<vault>/.mcbrain/{venv,bin}/` if missing.
+2. Run `python3 -m venv .mcbrain/venv` if the venv isn't there.
+3. Install pinned packages from `mcbrain-ops/references/requirements.txt` into the venv.
+4. Copy `mcbrain_ops.py` and `schema.sql` from this skill's `references/` directory into `<vault>/.mcbrain/bin/`.
+5. Patch the vault's `CLAUDE.md`: ensure a `## Query engine` section exists (with `mode`, `embedding_model`, `embedding_dim`, `index_path` keys); rewrite `## Operations → Query` to delegate to this skill; append `index sync` to ingest/update operations.
+6. Run an initial `index rebuild` to seed the database.
+
+This is the same logic `mcbrain-setup` Step 8.5 executes; the setup skill simply delegates here so there's one implementation.
+
+### `uninstall`
+
+Removes `<vault>/.mcbrain/` (venv, scripts, index). Does NOT touch `wiki/`, `raw/`, or any other vault content. Optionally cleans up the FastEmbed shared cache if it can detect that no other vaults reference it (best-effort — by default leaves the shared cache alone).
+
+## Cross-platform paths
+
+Per locked design decision #12 (cross-platform: macOS, Linux, Windows), every path the script constructs must use `pathlib.Path`, not string concatenation. The venv interpreter lives at:
+
+- POSIX: `<vault>/.mcbrain/venv/bin/python`
+- Windows: `<vault>/.mcbrain/venv/Scripts/python.exe`
+
+The script must detect the host and pick the right path. Same applies to `pip` (`venv/bin/pip` vs `venv/Scripts/pip.exe`).
+
+## What this skill does not do
+
+- It does not invoke system package managers (no `brew`, `winget`, `apt`, `dnf`). Per locked decision #11, McBrain only detects and surfaces install instructions for system prerequisites; the user installs Python and ripgrep themselves.
+- It does not modify `wiki/` or `raw/`. Read-only against vault content.
+- It does not call out to any cloud service. Everything runs locally on the user's machine.
+
+## Reference files
+
+- `references/requirements.txt` — pinned `fastembed` and `sqlite-vec` versions
+- `references/schema.sql` — SQLite schema (chunks + chunk_vec virtual table + meta)
+- `references/mcbrain_ops.py` — the dispatcher script copied into each vault during provisioning
+- `references/gitignore-snippet.md` — the gitignore lines that go into git-strategy vaults

--- a/plugins/mcbrain/skills/mcbrain-ops/references/gitignore-snippet.md
+++ b/plugins/mcbrain/skills/mcbrain-ops/references/gitignore-snippet.md
@@ -1,0 +1,25 @@
+# gitignore snippet for McBrain query engine
+
+This file is consumed by `mcbrain-setup` Step 3 (when the user picked git as their backup strategy) and by `mcbrain-ops migrate` (when retrofitting an existing git-strategy vault). It documents which paths under `.mcbrain/` should be ignored by git and which should be tracked.
+
+## Lines to append to `<vault>/.gitignore`
+
+```
+.mcbrain/venv/
+.mcbrain/index.db
+.mcbrain/index.db-*
+__pycache__/
+```
+
+## What stays tracked
+
+`.mcbrain/bin/` is **intentionally not ignored** — the indexer script (`mcbrain_ops.py`) and schema (`schema.sql`) must travel with the vault so a fresh clone can rebuild the venv and reproduce the index. Everything that's reproducible from the script + the wiki content (the venv itself, the index database, sqlite WAL/SHM files, Python bytecode) is ignored.
+
+## Why each line
+
+| Line | Reason |
+|---|---|
+| `.mcbrain/venv/` | Python venv. Platform-specific binaries (macOS x86_64 vs arm64 vs Linux vs Windows). Reproducible from `requirements.txt`. |
+| `.mcbrain/index.db` | The SQLite index. Reproducible from the wiki via `mcbrain-ops index rebuild`. Also large for big vaults; bloats git history. |
+| `.mcbrain/index.db-*` | sqlite-vec writes WAL (`*-wal`) and shared-memory (`*-shm`) sidecar files; these are transient. |
+| `__pycache__/` | Python bytecode cache. Generated on demand. |

--- a/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py
+++ b/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py
@@ -588,34 +588,46 @@ def cmd_query(vault: Path, text: str, k: int) -> int:
 
     db_path = index_db_path(vault)
     semantic_ranks: list[str] = []
-    chunks_by_path: dict[str, str] = {}
+    excerpts: dict[str, str] = {}
 
-    if db_path.exists():
-        conn = open_db(vault)
-        try:
+    conn: sqlite3.Connection | None = None
+    try:
+        if db_path.exists():
+            conn = open_db(vault)
             check_model_compatibility(conn, vault)
             sem = semantic_search(conn, text)
             semantic_ranks = [path for path, _ in sem]
-            for row in conn.execute("SELECT path, text FROM chunks").fetchall():
-                chunks_by_path[row["path"]] = row["text"]
-        finally:
+        else:
+            warn(
+                "no index — running lexical-only. "
+                f"Run `mcbrain-ops migrate --vault {vault}` to enable semantic search."
+            )
+
+        lex = lexical_search(vault, text)
+        lexical_ranks = [path for path, _ in lex]
+
+        rank_inputs = [r for r in (lexical_ranks, semantic_ranks) if r]
+        fused = rrf_fuse(rank_inputs)
+        ordered = sorted(fused.items(), key=lambda x: (-x[1], x[0]))[:k]
+        top_paths = [path for path, _ in ordered]
+
+        # Lazy text fetch: only SELECT text for the K paths that survived RRF,
+        # not every chunk in the index. Keeps per-query memory bounded by k×
+        # average page size instead of N× average page size.
+        if conn is not None and top_paths:
+            placeholders = ",".join("?" * len(top_paths))
+            for row in conn.execute(
+                f"SELECT path, text FROM chunks WHERE path IN ({placeholders})",
+                top_paths,
+            ).fetchall():
+                excerpts[row["path"]] = row["text"]
+    finally:
+        if conn is not None:
             conn.close()
-    else:
-        warn(
-            "no index — running lexical-only. "
-            f"Run `mcbrain-ops migrate --vault {vault}` to enable semantic search."
-        )
-
-    lex = lexical_search(vault, text)
-    lexical_ranks = [path for path, _ in lex]
-
-    rank_inputs = [r for r in (lexical_ranks, semantic_ranks) if r]
-    fused = rrf_fuse(rank_inputs)
-    ordered = sorted(fused.items(), key=lambda x: (-x[1], x[0]))[:k]
 
     results = []
     for path, score in ordered:
-        text_for_excerpt = chunks_by_path.get(path)
+        text_for_excerpt = excerpts.get(path)
         if text_for_excerpt is None:
             full = vault / path
             if full.is_file():

--- a/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py
+++ b/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py
@@ -838,6 +838,21 @@ INDEX_SYNC_STEP_TEXT = (
 )
 
 
+GENERAL_SYNC_RULE = (
+    "**Always sync the search index after any wiki write.** Whenever you "
+    "create, modify, or delete a file under `wiki/` — whether through a "
+    "formal ingest, a lint pass that updates `log.md`, an ad-hoc page "
+    "update, or a synthesis filing — invoke the `mcbrain-ops` skill "
+    "(`index sync`) afterward so subsequent queries see the change. Cheap "
+    "(sub-second on no-op). The specific operation procedures below all "
+    "end with this step explicitly; this paragraph is the catch-all for "
+    "anything not enumerated."
+)
+
+
+GENERAL_SYNC_RULE_MARKER = "Always sync the search index after any wiki write"
+
+
 def patch_claude_md(vault: Path) -> bool:
     """Idempotently update CLAUDE.md to advertise the query engine.
 
@@ -856,6 +871,7 @@ def patch_claude_md(vault: Path) -> bool:
 
     text = _replace_query_section(text)
     text = _ensure_index_sync_tail(text)
+    text = _ensure_general_sync_rule(text)
 
     if text == original:
         return False
@@ -882,6 +898,39 @@ def _replace_query_section(text: str) -> str:
         + NEW_QUERY_OPERATION.rstrip()
         + "\n\n"
         + text[end:].lstrip("\n")
+    )
+
+
+def _ensure_general_sync_rule(text: str) -> str:
+    """Insert the catch-all 'always sync after any wiki write' rule
+    immediately under `## Operations`, if not already there.
+
+    Idempotent: detects existing presence by `GENERAL_SYNC_RULE_MARKER`.
+    Without this rule, Claude only runs index sync after the formally
+    enumerated procedures (Ingest from raw/, Ingest from Notion); ad-hoc
+    edits and lint pass log writes would silently drift the index.
+    """
+    if GENERAL_SYNC_RULE_MARKER in text:
+        return text
+    header = "## Operations"
+    start = text.find(header)
+    if start < 0:
+        return text
+    # Insert immediately after the header line and the blank line that follows.
+    line_end = text.find("\n", start)
+    if line_end < 0:
+        return text
+    insertion_point = line_end + 1
+    # Skip a single trailing blank line if present so the inserted paragraph
+    # sits directly under the header with one blank-line gap on each side.
+    if text[insertion_point : insertion_point + 1] == "\n":
+        insertion_point += 1
+    return (
+        text[:insertion_point]
+        + "\n"
+        + GENERAL_SYNC_RULE
+        + "\n\n"
+        + text[insertion_point:].lstrip("\n")
     )
 
 

--- a/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py
+++ b/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py
@@ -1,0 +1,1000 @@
+#!/usr/bin/env python3
+"""mcbrain-ops — hybrid lexical + semantic query engine for a McBrain vault.
+
+Single-file dispatcher with six subcommands: query, index sync, index rebuild,
+index status, migrate, uninstall. Per-vault venv at <vault>/.mcbrain/venv/,
+per-vault SQLite index at <vault>/.mcbrain/index.db, shared FastEmbed model
+cache at ~/.cache/fastembed/ (FastEmbed default).
+
+Heavy dependencies (fastembed, sqlite-vec) are imported lazily inside the
+subcommand handlers so this file can also bootstrap a vault from system python
+(migrate creates the venv and pip-installs the deps) and so --help / uninstall
+work without them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
+EMBEDDING_DIM = 384
+SCHEMA_VERSION = "1"
+RRF_K = 60
+LEXICAL_LIMIT = 50
+SEMANTIC_LIMIT = 50
+
+
+# ----------------------------- Path helpers ---------------------------------
+
+
+def is_windows() -> bool:
+    return platform.system() == "Windows"
+
+
+def resolve_vault(arg: str | None) -> Path:
+    candidate = arg or os.environ.get("MCBRAIN_VAULT")
+    if not candidate:
+        die(
+            "vault path not provided. Pass --vault <path> or set MCBRAIN_VAULT.",
+            code=2,
+        )
+    p = Path(candidate).expanduser().resolve()
+    if not p.is_dir():
+        die(f"vault path is not a directory: {p}", code=2)
+    return p
+
+
+def mcbrain_dir(vault: Path) -> Path:
+    return vault / ".mcbrain"
+
+
+def venv_dir(vault: Path) -> Path:
+    return mcbrain_dir(vault) / "venv"
+
+
+def venv_python(vault: Path) -> Path:
+    if is_windows():
+        return venv_dir(vault) / "Scripts" / "python.exe"
+    return venv_dir(vault) / "bin" / "python"
+
+
+def venv_pip(vault: Path) -> Path:
+    if is_windows():
+        return venv_dir(vault) / "Scripts" / "pip.exe"
+    return venv_dir(vault) / "bin" / "pip"
+
+
+def bin_dir(vault: Path) -> Path:
+    return mcbrain_dir(vault) / "bin"
+
+
+def index_db_path(vault: Path) -> Path:
+    return mcbrain_dir(vault) / "index.db"
+
+
+def wiki_dir(vault: Path) -> Path:
+    return vault / "wiki"
+
+
+def claude_md_path(vault: Path) -> Path:
+    return vault / "CLAUDE.md"
+
+
+def script_source_dir() -> Path:
+    """Where this script lives — used by migrate to copy reference files."""
+    return Path(__file__).resolve().parent
+
+
+# ------------------------------ Diagnostics ---------------------------------
+
+
+def die(msg: str, code: int = 1) -> None:
+    print(f"mcbrain-ops: error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def warn(msg: str) -> None:
+    print(f"mcbrain-ops: warning: {msg}", file=sys.stderr)
+
+
+def info(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+# --------------------------------- DB ---------------------------------------
+
+
+def open_db(vault: Path) -> sqlite3.Connection:
+    db_path = index_db_path(vault)
+    if not db_path.exists():
+        die(
+            f"no index at {db_path}. Run `mcbrain-ops migrate --vault {vault}` "
+            "to provision this vault.",
+            code=3,
+        )
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(db_path: Path, schema_sql_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    with open(schema_sql_path, "r", encoding="utf-8") as f:
+        conn.executescript(f.read())
+    set_meta(conn, "embedding_model", EMBEDDING_MODEL)
+    set_meta(conn, "embedding_dim", str(EMBEDDING_DIM))
+    set_meta(conn, "schema_version", SCHEMA_VERSION)
+    conn.commit()
+    conn.close()
+
+
+def get_meta(conn: sqlite3.Connection, key: str) -> str | None:
+    row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+    return row["value"] if row else None
+
+
+def set_meta(conn: sqlite3.Connection, key: str, value: str) -> None:
+    conn.execute(
+        "INSERT INTO meta(key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, value),
+    )
+
+
+# ----------------------------- Embedder cache -------------------------------
+
+
+_embedder = None
+
+
+def get_embedder():
+    """Lazy singleton for the FastEmbed model. Cached process-wide."""
+    global _embedder
+    if _embedder is None:
+        try:
+            from fastembed import TextEmbedding  # type: ignore
+        except ImportError:
+            die(
+                "fastembed not installed in this Python. Run "
+                "`mcbrain-ops migrate --vault <vault>` to provision the venv.",
+                code=4,
+            )
+        _embedder = TextEmbedding(model_name=EMBEDDING_MODEL)
+    return _embedder
+
+
+def _np():
+    try:
+        import numpy as np  # type: ignore
+    except ImportError:
+        die(
+            "numpy not installed in this Python. Run "
+            "`mcbrain-ops migrate --vault <vault>` to provision the venv.",
+            code=4,
+        )
+    return np
+
+
+def embed_one(text: str) -> "np.ndarray":  # noqa: F821
+    """Embed a single string. Returns a float32 numpy array of length EMBEDDING_DIM."""
+    np = _np()
+    emb = list(get_embedder().embed([text]))[0]
+    return np.asarray(emb, dtype=np.float32)
+
+
+def embed_many(texts: list[str]) -> list["np.ndarray"]:  # noqa: F821
+    np = _np()
+    return [np.asarray(v, dtype=np.float32) for v in get_embedder().embed(texts)]
+
+
+def embedding_to_blob(vec) -> bytes:
+    np = _np()
+    return np.ascontiguousarray(vec, dtype=np.float32).tobytes()
+
+
+def blob_to_embedding(blob: bytes):
+    np = _np()
+    return np.frombuffer(blob, dtype=np.float32)
+
+
+# --------------------------- Wiki discovery ---------------------------------
+
+
+def discover_wiki_files(vault: Path) -> list[Path]:
+    wiki = wiki_dir(vault)
+    if not wiki.is_dir():
+        return []
+    return sorted(p for p in wiki.rglob("*.md") if p.is_file())
+
+
+def hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def relative_wiki_path(vault: Path, path: Path) -> str:
+    """Vault-relative path with forward slashes (cross-platform stable key)."""
+    return path.resolve().relative_to(vault.resolve()).as_posix()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+# ----------------------------- index sync -----------------------------------
+
+
+def cmd_sync(vault: Path) -> int:
+    schema_path = bin_dir(vault) / "schema.sql"
+    if not index_db_path(vault).exists():
+        if not schema_path.exists():
+            die(
+                f"index missing and schema.sql not found at {schema_path}. "
+                f"Run `mcbrain-ops migrate --vault {vault}` first.",
+                code=3,
+            )
+        init_db(index_db_path(vault), schema_path)
+
+    conn = open_db(vault)
+    try:
+        check_model_compatibility(conn, vault)
+
+        files = discover_wiki_files(vault)
+        wanted: dict[str, tuple[Path, str]] = {}
+        for p in files:
+            key = relative_wiki_path(vault, p)
+            wanted[key] = (p, hash_file(p))
+
+        existing = {
+            row["path"]: row["content_hash"]
+            for row in conn.execute("SELECT path, content_hash FROM chunks").fetchall()
+        }
+
+        added = [k for k in wanted if k not in existing]
+        changed = [k for k in wanted if k in existing and existing[k] != wanted[k][1]]
+        removed = [k for k in existing if k not in wanted]
+
+        if added:
+            info(f"sync: embedding {len(added)} new pages")
+            for key in added:
+                upsert_chunk(conn, vault, key, wanted[key][0], wanted[key][1])
+        if changed:
+            info(f"sync: re-embedding {len(changed)} changed pages")
+            for key in changed:
+                upsert_chunk(conn, vault, key, wanted[key][0], wanted[key][1])
+        if removed:
+            info(f"sync: removing {len(removed)} deleted pages")
+            for key in removed:
+                delete_chunk(conn, key)
+
+        set_meta(conn, "last_sync", iso_now())
+        conn.commit()
+        if not (added or changed or removed):
+            info("sync: no changes")
+        info(
+            f"sync: done — added={len(added)} changed={len(changed)} "
+            f"removed={len(removed)} total={len(wanted)}"
+        )
+        return 0
+    finally:
+        conn.close()
+
+
+def upsert_chunk(
+    conn: sqlite3.Connection,
+    vault: Path,
+    key: str,
+    path: Path,
+    content_hash: str,
+) -> None:
+    text = read_text(path)
+    mtime = path.stat().st_mtime
+    embedding = embed_one(text)
+    blob = embedding_to_blob(embedding)
+
+    existing = conn.execute("SELECT id FROM chunks WHERE path = ?", (key,)).fetchone()
+    if existing is None:
+        conn.execute(
+            "INSERT INTO chunks(path, content_hash, text, mtime, embedding) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (key, content_hash, text, mtime, blob),
+        )
+    else:
+        conn.execute(
+            "UPDATE chunks SET content_hash = ?, text = ?, mtime = ?, embedding = ? "
+            "WHERE id = ?",
+            (content_hash, text, mtime, blob, existing["id"]),
+        )
+
+
+def delete_chunk(conn: sqlite3.Connection, key: str) -> None:
+    conn.execute("DELETE FROM chunks WHERE path = ?", (key,))
+
+
+# ----------------------------- index rebuild --------------------------------
+
+
+def cmd_rebuild(vault: Path) -> int:
+    db_path = index_db_path(vault)
+    schema_path = bin_dir(vault) / "schema.sql"
+    if not schema_path.exists():
+        die(
+            f"schema.sql not found at {schema_path}. Run "
+            f"`mcbrain-ops migrate --vault {vault}` first.",
+            code=3,
+        )
+    if db_path.exists():
+        db_path.unlink()
+    init_db(db_path, schema_path)
+
+    conn = open_db(vault)
+    try:
+        files = discover_wiki_files(vault)
+        if not files:
+            info("rebuild: no wiki files yet — empty index initialized")
+            set_meta(conn, "last_rebuild", iso_now())
+            set_meta(conn, "last_sync", iso_now())
+            conn.commit()
+            return 0
+
+        info(f"rebuild: embedding {len(files)} wiki pages")
+        texts = [read_text(p) for p in files]
+        embeddings = embed_many(texts)
+        for path, text, embedding in zip(files, texts, embeddings):
+            key = relative_wiki_path(vault, path)
+            content_hash = hash_file(path)
+            mtime = path.stat().st_mtime
+            conn.execute(
+                "INSERT INTO chunks(path, content_hash, text, mtime, embedding) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (key, content_hash, text, mtime, embedding_to_blob(embedding)),
+            )
+
+        set_meta(conn, "last_rebuild", iso_now())
+        set_meta(conn, "last_sync", iso_now())
+        conn.commit()
+        info(f"rebuild: done — {len(files)} pages indexed")
+        return 0
+    finally:
+        conn.close()
+
+
+def check_model_compatibility(conn: sqlite3.Connection, vault: Path) -> None:
+    stored_model = get_meta(conn, "embedding_model")
+    stored_dim = get_meta(conn, "embedding_dim")
+    if stored_model != EMBEDDING_MODEL or stored_dim != str(EMBEDDING_DIM):
+        die(
+            f"index was built with model={stored_model} dim={stored_dim} but "
+            f"current code expects {EMBEDDING_MODEL} dim={EMBEDDING_DIM}. "
+            f"Run `mcbrain-ops index rebuild --vault {vault}`.",
+            code=6,
+        )
+
+
+# ----------------------------- index status ---------------------------------
+
+
+def cmd_status(vault: Path) -> int:
+    db_path = index_db_path(vault)
+    out: dict = {
+        "vault": str(vault),
+        "index_path": str(db_path),
+        "provisioned": db_path.exists(),
+    }
+    if not db_path.exists():
+        print(json.dumps(out, indent=2))
+        return 0
+
+    out["index_size_bytes"] = db_path.stat().st_size
+    conn = open_db(vault)
+    try:
+        out["embedding_model"] = get_meta(conn, "embedding_model")
+        out["embedding_dim"] = int(get_meta(conn, "embedding_dim") or 0)
+        out["schema_version"] = get_meta(conn, "schema_version")
+        out["last_sync"] = get_meta(conn, "last_sync")
+        out["last_rebuild"] = get_meta(conn, "last_rebuild")
+        out["doc_count"] = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    finally:
+        conn.close()
+
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+# ----------------------------- lexical search -------------------------------
+
+
+def lexical_search(vault: Path, text: str) -> list[tuple[str, int]]:
+    """Return [(rel_path, hit_count), ...] sorted by hit_count desc.
+
+    Uses ripgrep when available; falls back to grep on POSIX or a Python
+    walker when neither is found. The actual hit count is what we use for
+    a within-modality rank — the absolute value isn't fed into RRF, just
+    the rank ordering.
+    """
+    wiki = wiki_dir(vault)
+    if not wiki.is_dir():
+        return []
+
+    if shutil.which("rg"):
+        return _rg_search(wiki, text)
+    if shutil.which("grep") and not is_windows():
+        return _grep_search(wiki, text)
+    return _python_search(wiki, text)
+
+
+def _rg_search(wiki: Path, text: str) -> list[tuple[str, int]]:
+    cmd = [
+        "rg",
+        "--type", "md",
+        "--count-matches",
+        "--no-heading",
+        "--ignore-case",
+        "--",
+        text,
+        str(wiki),
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        warn("rg timed out; falling back to no lexical results")
+        return []
+    if result.returncode not in (0, 1):
+        warn(f"rg exited {result.returncode}; falling back to no lexical results")
+        return []
+    return _parse_count_lines(result.stdout, wiki)
+
+
+def _grep_search(wiki: Path, text: str) -> list[tuple[str, int]]:
+    cmd = [
+        "grep",
+        "-r",
+        "-i",
+        "-c",
+        "--include=*.md",
+        text,
+        str(wiki),
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        warn("grep timed out; falling back to no lexical results")
+        return []
+    return _parse_count_lines(result.stdout, wiki)
+
+
+def _parse_count_lines(stdout: str, wiki: Path) -> list[tuple[str, int]]:
+    out: list[tuple[str, int]] = []
+    vault = wiki.parent
+    for line in stdout.splitlines():
+        if not line:
+            continue
+        try:
+            path_str, count_str = line.rsplit(":", 1)
+            count = int(count_str)
+        except ValueError:
+            continue
+        if count <= 0:
+            continue
+        try:
+            rel = Path(path_str).resolve().relative_to(vault.resolve()).as_posix()
+        except ValueError:
+            continue
+        out.append((rel, count))
+    out.sort(key=lambda x: (-x[1], x[0]))
+    return out[:LEXICAL_LIMIT]
+
+
+def _python_search(wiki: Path, text: str) -> list[tuple[str, int]]:
+    needle = text.lower()
+    vault = wiki.parent
+    results: list[tuple[str, int]] = []
+    for path in wiki.rglob("*.md"):
+        if not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace").lower()
+        except OSError:
+            continue
+        count = content.count(needle)
+        if count > 0:
+            try:
+                rel = path.resolve().relative_to(vault.resolve()).as_posix()
+            except ValueError:
+                continue
+            results.append((rel, count))
+    results.sort(key=lambda x: (-x[1], x[0]))
+    return results[:LEXICAL_LIMIT]
+
+
+# ----------------------------- semantic search ------------------------------
+
+
+def semantic_search(conn: sqlite3.Connection, text: str) -> list[tuple[str, float]]:
+    """Return [(rel_path, similarity), ...] sorted by similarity desc (higher = better).
+
+    Brute-force cosine similarity over the entire chunks table. Fast in numpy
+    even at low-thousands of pages.
+    """
+    np = _np()
+    rows = conn.execute("SELECT path, embedding FROM chunks").fetchall()
+    if not rows:
+        return []
+
+    paths = [row["path"] for row in rows]
+    matrix = np.stack([blob_to_embedding(row["embedding"]) for row in rows])
+
+    query_vec = embed_one(text)
+
+    # Cosine similarity: dot(a, b) / (||a|| * ||b||).
+    # FastEmbed bge-small-en-v1.5 returns normalized vectors, so dot is enough,
+    # but normalize defensively in case the model or version changes.
+    matrix_norms = np.linalg.norm(matrix, axis=1)
+    query_norm = np.linalg.norm(query_vec)
+    safe_denom = np.where(matrix_norms == 0, 1.0, matrix_norms) * (
+        query_norm if query_norm != 0 else 1.0
+    )
+    sims = (matrix @ query_vec) / safe_denom
+
+    order = np.argsort(-sims)[:SEMANTIC_LIMIT]
+    return [(paths[i], float(sims[i])) for i in order]
+
+
+# ----------------------------- query / RRF ----------------------------------
+
+
+def rrf_fuse(rank_lists: list[list[str]], k: int = RRF_K) -> dict[str, float]:
+    """Reciprocal Rank Fusion. Each rank_list is an ordered list of paths
+    (rank 0 = best). Returns {path: fused_score}."""
+    scores: dict[str, float] = {}
+    for ranks in rank_lists:
+        for rank, path in enumerate(ranks):
+            scores[path] = scores.get(path, 0.0) + 1.0 / (k + rank + 1)
+    return scores
+
+
+def make_excerpt(text: str, max_chars: int = 240) -> str:
+    snippet = text.strip().splitlines()
+    body = ""
+    for line in snippet:
+        line = line.strip()
+        if not line or line.startswith("---") or line.startswith("#"):
+            continue
+        body = line
+        break
+    if not body:
+        body = " ".join(text.split())
+    return (body[:max_chars] + "…") if len(body) > max_chars else body
+
+
+def cmd_query(vault: Path, text: str, k: int) -> int:
+    if not text.strip():
+        die("query text was empty", code=2)
+
+    db_path = index_db_path(vault)
+    semantic_ranks: list[str] = []
+    chunks_by_path: dict[str, str] = {}
+
+    if db_path.exists():
+        conn = open_db(vault)
+        try:
+            check_model_compatibility(conn, vault)
+            sem = semantic_search(conn, text)
+            semantic_ranks = [path for path, _ in sem]
+            for row in conn.execute("SELECT path, text FROM chunks").fetchall():
+                chunks_by_path[row["path"]] = row["text"]
+        finally:
+            conn.close()
+    else:
+        warn(
+            "no index — running lexical-only. "
+            f"Run `mcbrain-ops migrate --vault {vault}` to enable semantic search."
+        )
+
+    lex = lexical_search(vault, text)
+    lexical_ranks = [path for path, _ in lex]
+
+    rank_inputs = [r for r in (lexical_ranks, semantic_ranks) if r]
+    fused = rrf_fuse(rank_inputs)
+    ordered = sorted(fused.items(), key=lambda x: (-x[1], x[0]))[:k]
+
+    results = []
+    for path, score in ordered:
+        text_for_excerpt = chunks_by_path.get(path)
+        if text_for_excerpt is None:
+            full = vault / path
+            if full.is_file():
+                try:
+                    text_for_excerpt = read_text(full)
+                except OSError:
+                    text_for_excerpt = ""
+            else:
+                text_for_excerpt = ""
+        results.append(
+            {
+                "path": path,
+                "score": round(score, 6),
+                "excerpt": make_excerpt(text_for_excerpt),
+            }
+        )
+
+    print(
+        json.dumps(
+            {
+                "query": text,
+                "k": k,
+                "mode": "lexical+semantic" if semantic_ranks else "lexical",
+                "results": results,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+# -------------------------------- migrate -----------------------------------
+
+
+def cmd_migrate(vault: Path, no_rebuild: bool = False) -> int:
+    info(f"migrate: target vault {vault}")
+    mcb = mcbrain_dir(vault)
+    bin_d = bin_dir(vault)
+    bin_d.mkdir(parents=True, exist_ok=True)
+
+    src_dir = script_source_dir()
+    script_src = src_dir / "mcbrain_ops.py"
+    schema_src = src_dir / "schema.sql"
+    requirements_src = src_dir / "requirements.txt"
+    for required in (script_src, schema_src, requirements_src):
+        if not required.is_file():
+            die(
+                f"reference file missing: {required}. The migrate command must "
+                "be run from the mcbrain-ops skill directory or from a copy of "
+                "mcbrain_ops.py that has its references/ siblings present.",
+                code=7,
+            )
+
+    script_dst = bin_d / "mcbrain_ops.py"
+    schema_dst = bin_d / "schema.sql"
+    if not script_dst.exists() or hash_file(script_src) != hash_file(script_dst):
+        shutil.copy2(script_src, script_dst)
+        info(f"migrate: copied mcbrain_ops.py -> {script_dst}")
+    if not schema_dst.exists() or hash_file(schema_src) != hash_file(schema_dst):
+        shutil.copy2(schema_src, schema_dst)
+        info(f"migrate: copied schema.sql -> {schema_dst}")
+
+    ensure_venv(vault)
+    install_requirements(vault, requirements_src)
+
+    patched = patch_claude_md(vault)
+    if patched:
+        info(f"migrate: patched {claude_md_path(vault)}")
+    else:
+        info(f"migrate: {claude_md_path(vault)} already up to date")
+
+    if no_rebuild:
+        info("migrate: skipping initial index rebuild (--no-rebuild)")
+    else:
+        info("migrate: running initial `index rebuild` in venv")
+        result = run_in_venv(vault, ["index", "rebuild"])
+        if result != 0:
+            warn(f"initial rebuild exited {result} — run it manually to retry")
+            return result
+
+    info("migrate: done")
+    return 0
+
+
+def ensure_venv(vault: Path) -> None:
+    vpy = venv_python(vault)
+    if vpy.is_file():
+        return
+    venv_dir(vault).parent.mkdir(parents=True, exist_ok=True)
+    if shutil.which("python3"):
+        py = "python3"
+    elif shutil.which("python"):
+        py = "python"
+    else:
+        die(
+            "no python3 found on PATH. Install Python 3.10+ from python.org "
+            "(macOS / Windows) or via your distro package manager (Linux), "
+            "then re-run migrate.",
+            code=8,
+        )
+    info(f"migrate: creating venv at {venv_dir(vault)}")
+    result = subprocess.run(
+        [py, "-m", "venv", str(venv_dir(vault))],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        die(
+            f"failed to create venv: {result.stderr.strip() or result.stdout.strip()}",
+            code=8,
+        )
+    if not vpy.is_file():
+        die(
+            f"venv created but interpreter missing at {vpy}. The Python install "
+            "may be incomplete — try reinstalling Python.",
+            code=8,
+        )
+
+
+def install_requirements(vault: Path, requirements: Path) -> None:
+    pip = venv_pip(vault)
+    if not pip.is_file():
+        die(f"venv pip missing at {pip}", code=8)
+    info("migrate: installing pinned requirements (this can take a minute)")
+    result = subprocess.run(
+        [str(pip), "install", "--quiet", "-r", str(requirements)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        die(
+            f"pip install failed:\n{result.stdout}\n{result.stderr}",
+            code=8,
+        )
+
+
+def run_in_venv(vault: Path, subargs: list[str]) -> int:
+    """Re-invoke the installed mcbrain_ops.py inside the venv."""
+    vpy = venv_python(vault)
+    script = bin_dir(vault) / "mcbrain_ops.py"
+    if not vpy.is_file() or not script.is_file():
+        die(
+            f"venv or installed script missing — cannot run subcommand {subargs}.",
+            code=8,
+        )
+    cmd = [str(vpy), str(script), *subargs, "--vault", str(vault)]
+    return subprocess.call(cmd)
+
+
+# ----------------------- CLAUDE.md patcher (migrate) -------------------------
+
+
+QUERY_ENGINE_SECTION = f"""## Query engine
+
+- mode: lexical+semantic
+- embedding_model: {EMBEDDING_MODEL}
+- embedding_dim: {EMBEDDING_DIM}
+- index_path: .mcbrain/index.db
+
+The query engine is hybrid: lexical (ripgrep / grep / pure-Python fallback)
+plus semantic (FastEmbed for embeddings, brute-force cosine via numpy over a
+SQLite-stored embedding column). Results from the two modalities are fused via
+Reciprocal Rank Fusion. The per-vault index lives at `.mcbrain/index.db` and
+is provisioned and maintained by the `mcbrain-ops` skill. Re-index with
+`mcbrain-ops index rebuild` if the schema or model ever changes.
+"""
+
+
+NEW_QUERY_OPERATION = """### Query
+When asked a question against the wiki:
+1. Invoke the `mcbrain-ops` skill (`query "<text>"`). It returns a ranked list of wiki page paths + scores as JSON.
+2. Read the top 5–8 pages from that list.
+3. Synthesize an answer with `[[wikilinks]]` citations.
+4. Offer to file the answer as a new wiki page if it's worth keeping.
+
+`wiki/index.md` is no longer the retrieval mechanism — it stays for human browsing and lint only.
+
+Answers don't have to be prose. Pick the format that fits the question:
+- **Markdown page** — the default; file-able back into the wiki as a new synthesis page
+- **Comparison table** — for "how does X differ from Y?" questions
+- **Marp slide deck** (`.md` with Marp frontmatter) — for presentations or sequential walkthroughs
+- **Chart** (matplotlib via `python3`, or a rendered image saved to `raw/assets/`) — for questions about trends, distributions, or quantitative comparisons
+- **Canvas / diagram** — for questions about relationships, flows, or architecture
+
+If the output form is reusable knowledge (not just a one-off), offer to file it as a wiki page so the exploration compounds.
+"""
+
+
+INDEX_SYNC_STEP_TEXT = (
+    "Invoke the `mcbrain-ops` skill (`index sync`) so the new wiki page(s) "
+    "are searchable immediately."
+)
+
+
+def patch_claude_md(vault: Path) -> bool:
+    """Idempotently update CLAUDE.md to advertise the query engine.
+
+    Returns True if any change was written, False if the file was already
+    up to date.
+    """
+    cmd = claude_md_path(vault)
+    if not cmd.is_file():
+        warn(f"no CLAUDE.md at {cmd} — skipping CLAUDE.md patch")
+        return False
+    original = cmd.read_text(encoding="utf-8")
+    text = original
+
+    if "## Query engine" not in text:
+        text = text.rstrip() + "\n\n" + QUERY_ENGINE_SECTION
+
+    text = _replace_query_section(text)
+    text = _ensure_index_sync_tail(text)
+
+    if text == original:
+        return False
+    cmd.write_text(text, encoding="utf-8")
+    return True
+
+
+def _replace_query_section(text: str) -> str:
+    """Replace the legacy `### Query` block under `## Operations` with the new one.
+
+    The block ends at the next heading at any level (H1–H6), so the replacement
+    doesn't accidentally swallow nested `#### ...` subsections that happen to
+    follow it.
+    """
+    marker = "### Query"
+    start = text.find(marker)
+    if start < 0:
+        return text
+    end = _find_next_heading(text, start + len(marker))
+    if "mcbrain-ops" in text[start:end]:
+        return text
+    return (
+        text[:start]
+        + NEW_QUERY_OPERATION.rstrip()
+        + "\n\n"
+        + text[end:].lstrip("\n")
+    )
+
+
+def _find_next_heading(text: str, search_from: int) -> int:
+    """Return the index of the next markdown heading line, or len(text)."""
+    i = search_from
+    while True:
+        nl = text.find("\n", i)
+        if nl < 0:
+            return len(text)
+        if text[nl + 1 : nl + 2] == "#":
+            return nl + 1
+        i = nl + 1
+
+
+def _ensure_index_sync_tail(text: str) -> str:
+    """Append an `index sync` step to the `Ingest from raw/` numbered list,
+    if not already present. Increments the highest numbered step in the block
+    so it slots in cleanly regardless of the source list length."""
+    import re
+
+    header = "#### Ingest from raw/"
+    start = text.find(header)
+    if start < 0:
+        return text
+    end = _find_next_heading(text, start + len(header))
+    block = text[start:end]
+    if "mcbrain-ops" in block and "index sync" in block:
+        return text
+
+    numbered = re.findall(r"^\s*(\d+)\.\s", block, flags=re.MULTILINE)
+    next_num = (max(int(n) for n in numbered) + 1) if numbered else None
+    if next_num is not None:
+        new_step = f"{next_num}. {INDEX_SYNC_STEP_TEXT}\n"
+    else:
+        new_step = f"- {INDEX_SYNC_STEP_TEXT}\n"
+
+    appended = block.rstrip() + "\n" + new_step + "\n"
+    return text[:start] + appended + text[end:]
+
+
+# -------------------------------- uninstall ---------------------------------
+
+
+def cmd_uninstall(vault: Path, force: bool) -> int:
+    target = mcbrain_dir(vault)
+    if not target.exists():
+        info(f"uninstall: nothing to do — {target} doesn't exist")
+        return 0
+    if not force:
+        info(
+            f"uninstall: would remove {target} (venv, scripts, index). "
+            "Re-run with --force to actually delete."
+        )
+        return 0
+    shutil.rmtree(target)
+    info(f"uninstall: removed {target}")
+    info(
+        "note: the FastEmbed model cache at ~/.cache/fastembed/ is shared and "
+        "intentionally left in place; remove it manually if no other vaults "
+        "use it."
+    )
+    return 0
+
+
+# --------------------------------- helpers ----------------------------------
+
+
+def iso_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+# -------------------------------- argparse ----------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mcbrain-ops",
+        description="Hybrid lexical + semantic query engine for a McBrain vault.",
+    )
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--vault",
+        default=None,
+        help="Path to the McBrain vault. Defaults to MCBRAIN_VAULT env var.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_query = sub.add_parser(
+        "query", help="Hybrid lexical + semantic search", parents=[common]
+    )
+    p_query.add_argument("text", help="The query text")
+    p_query.add_argument("--k", type=int, default=8, help="Number of results (default 8)")
+
+    p_index = sub.add_parser("index", help="Index management")
+    isub = p_index.add_subparsers(dest="op", required=True)
+    isub.add_parser("sync", help="Incremental sync (changed files only)", parents=[common])
+    isub.add_parser("rebuild", help="Wipe and re-embed everything", parents=[common])
+    isub.add_parser("status", help="Print index status as JSON", parents=[common])
+
+    p_mig = sub.add_parser(
+        "migrate",
+        help="Provision .mcbrain/, install deps, build initial index, patch CLAUDE.md",
+        parents=[common],
+    )
+    p_mig.add_argument(
+        "--no-rebuild",
+        action="store_true",
+        help="Skip initial index rebuild (useful for tests)",
+    )
+
+    p_un = sub.add_parser("uninstall", help="Remove .mcbrain/", parents=[common])
+    p_un.add_argument(
+        "--force",
+        action="store_true",
+        help="Actually delete (otherwise dry-run)",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    vault = resolve_vault(args.vault)
+
+    if args.cmd == "query":
+        return cmd_query(vault, args.text, args.k)
+    if args.cmd == "index":
+        if args.op == "sync":
+            return cmd_sync(vault)
+        if args.op == "rebuild":
+            return cmd_rebuild(vault)
+        if args.op == "status":
+            return cmd_status(vault)
+    if args.cmd == "migrate":
+        return cmd_migrate(vault, no_rebuild=args.no_rebuild)
+    if args.cmd == "uninstall":
+        return cmd_uninstall(vault, force=args.force)
+    die(f"unknown command: {args.cmd}", code=2)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py
+++ b/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py
@@ -569,14 +569,30 @@ def rrf_fuse(rank_lists: list[list[str]], k: int = RRF_K) -> dict[str, float]:
 
 
 def make_excerpt(text: str, max_chars: int = 240) -> str:
-    snippet = text.strip().splitlines()
+    """Return a short excerpt of `text` for display in query results.
+
+    Skips a leading YAML frontmatter block (between `---` markers), markdown
+    headings, and blank lines, returning the first substantive body line.
+    Falls back to a flattened version of the whole text if nothing else qualifies.
+    """
+    lines = text.strip().splitlines()
+    in_frontmatter = False
+    if lines and lines[0].strip() == "---":
+        in_frontmatter = True
+        lines = lines[1:]
+
     body = ""
-    for line in snippet:
-        line = line.strip()
-        if not line or line.startswith("---") or line.startswith("#"):
+    for line in lines:
+        stripped = line.strip()
+        if in_frontmatter:
+            if stripped == "---":
+                in_frontmatter = False
             continue
-        body = line
+        if not stripped or stripped.startswith("#"):
+            continue
+        body = stripped
         break
+
     if not body:
         body = " ".join(text.split())
     return (body[:max_chars] + "…") if len(body) > max_chars else body

--- a/plugins/mcbrain/skills/mcbrain-ops/references/requirements.txt
+++ b/plugins/mcbrain/skills/mcbrain-ops/references/requirements.txt
@@ -1,0 +1,25 @@
+# McBrain Ops — pinned dependencies
+#
+# Installed by `mcbrain-ops migrate` (and equivalently by `mcbrain-setup` Step 8.5)
+# into the per-vault venv at <vault>/.mcbrain/venv/. Never installed system-wide.
+#
+# Versions checked 2026-05-01 against PyPI. Update with care — embedding model
+# compatibility and sqlite-vec API shape are both version-sensitive.
+#
+# fastembed: CPU-only ONNX embedding library. Ships BAAI/bge-small-en-v1.5
+# (384 dims, ~30 MB). Cache lives in ~/.cache/fastembed/ by default — shared
+# across all McBrain vaults so additional vaults don't re-download the model.
+fastembed==0.8.0
+
+# numpy: vector arithmetic for the brute-force cosine search path. Used to
+# rank wiki pages against a query embedding. fastembed already pulls numpy in
+# transitively, so this line is mostly a documentation pin.
+#
+# Why brute-force instead of sqlite-vec: sqlite-vec requires a SQLite built
+# with extension loading enabled (`conn.enable_load_extension`). Many Python
+# distributions on macOS — including pyenv-built Python and the system Python —
+# ship a stripped sqlite that disables this. Rather than gate the query engine
+# on the user having a specific Python build, we store embeddings as plain
+# BLOBs and compute cosine similarity in numpy. At personal-wiki scale
+# (low thousands of pages) this is essentially instant.
+numpy>=1.26,<3

--- a/plugins/mcbrain/skills/mcbrain-ops/references/schema.sql
+++ b/plugins/mcbrain/skills/mcbrain-ops/references/schema.sql
@@ -1,0 +1,33 @@
+-- McBrain Ops — index schema
+--
+-- Single SQLite database at <vault>/.mcbrain/index.db, populated and queried by
+-- mcbrain_ops.py. Embeddings are stored as raw float32 BLOBs and ranked at
+-- query time by computing cosine similarity in numpy. This avoids the
+-- sqlite-vec extension-loading requirement that breaks on Python builds
+-- without `enable_load_extension` (notably pyenv on macOS and the macOS
+-- system Python).
+--
+-- Per-page chunking (one row per wiki/*.md file) is the v1 strategy; if pages
+-- routinely exceed ~1500 tokens the schema still works but recall on long pages
+-- will suffer. A future change can split on H2 boundaries by appending more
+-- rows per path; the path UNIQUE constraint would need to be relaxed at that
+-- point.
+
+CREATE TABLE IF NOT EXISTS chunks (
+  id            INTEGER PRIMARY KEY,
+  path          TEXT    NOT NULL UNIQUE,    -- vault-relative path, e.g. "wiki/scaling-laws.md"
+  content_hash  TEXT    NOT NULL,           -- SHA-256 of file contents; drives incremental sync
+  text          TEXT    NOT NULL,           -- full chunk text (the embedded content)
+  mtime         REAL    NOT NULL,           -- file mtime at index time; informational, hash is authoritative
+  embedding     BLOB    NOT NULL            -- float32[384] little-endian, packed by numpy.ndarray.tobytes()
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_path ON chunks(path);
+
+-- Single-row meta table: holds the embedding model name, dimension, last sync,
+-- and schema version. mcbrain_ops.py reads this on every invocation to detect
+-- mismatches and trigger rebuilds when needed.
+CREATE TABLE IF NOT EXISTS meta (
+  key    TEXT PRIMARY KEY,
+  value  TEXT NOT NULL
+);

--- a/plugins/mcbrain/skills/mcbrain-setup/README.md
+++ b/plugins/mcbrain/skills/mcbrain-setup/README.md
@@ -31,8 +31,9 @@ End-to-end bootstrap for a new vault:
 - **Name and locate** — picks the vault name (`mcbrain-<topic>`) and filesystem path
 - **Backup strategy** — Git + GitHub (with remote repo created up front), Google Drive, or none
 - **Scaffold** — creates `raw/`, `wiki/`, and the starter files (`index.md`, `log.md`, `overview.md`, `CLAUDE.md`)
-- **CLAUDE.md** — writes the vault's source-of-truth config, including the Web Ingestion Routing and Backup sections
+- **CLAUDE.md** — writes the vault's source-of-truth config, including the Web Ingestion Routing, Backup, and Query engine sections
 - **MCP config** — merges the filesystem MCP block into `claude_desktop_config.json`
+- **Query engine** — provisions a per-vault Python venv at `<vault>/.mcbrain/venv/`, installs the indexer dependencies, builds the initial search index. Hybrid lexical + semantic, no system-wide installs. Detects `python3` and `rg` and surfaces install instructions if missing (does not run a system package manager itself).
 - **Obsidian + extensions** — walks through Obsidian vault setup, Claude in Chrome, and Obsidian Web Clipper
 - **Verify** — confirms Claude can read `CLAUDE.md` through the new MCP
 

--- a/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
+++ b/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
@@ -230,7 +230,7 @@ After all files are written:
 ```bash
 cd VAULT_PATH
 git init -b main
-printf '.DS_Store\n.obsidian/workspace*\n.obsidian/cache\n' > .gitignore
+printf '.DS_Store\n.obsidian/workspace*\n.obsidian/cache\n.mcbrain/venv/\n.mcbrain/index.db\n.mcbrain/index.db-*\n__pycache__/\n' > .gitignore
 git remote add origin REPO_URL
 git add -A
 git commit -m "init: MCP_NAME vault scaffolding"
@@ -238,6 +238,8 @@ git push -u origin main
 ```
 
 Confirm the push succeeded. If it fails, check that `gh auth login` completed correctly and that `REPO_URL` is reachable.
+
+The gitignore covers everything in `<vault>/.mcbrain/` that Step 8.5 will create *except* `.mcbrain/bin/`. The `bin/` directory holds the indexer script and SQL schema, which **are tracked** so the per-vault setup is reproducible from a fresh clone (a new machine pulls the repo, re-runs `mcbrain-ops migrate`, and gets back to a working query engine without redownloading the script). The venv and index database are not tracked because they're either platform-specific or rebuildable from the wiki content. See `mcbrain-ops/references/gitignore-snippet.md` for the per-line rationale.
 
 ---
 
@@ -284,6 +286,50 @@ Merge the following block under `"mcpServers"` (use the actual `MCP_NAME` value)
 If the file doesn't exist yet, create it with the full structure. If other MCP servers already exist, merge carefully — don't overwrite them.
 
 Show the user the final config before writing it and ask them to confirm.
+
+---
+
+## Step 5.5: Detect query-engine prerequisites (do not install)
+
+McBrain ships a hybrid lexical + semantic query engine (the `mcbrain-ops` skill) that gets provisioned in Step 8.5. It needs `python3` (>=3.10) for the per-vault venv and benefits from `ripgrep` (`rg`) for the lexical fast path. **McBrain never invokes a system package manager.** This step only *detects* what's available and *surfaces* platform-appropriate install instructions; the user installs the missing pieces themselves.
+
+**Detection has to work on every host**: macOS, Linux, Windows. Don't assume zsh/bash — the user could be in PowerShell, Git Bash, WSL, or cmd. Use `python3 --version` (then `python --version` as a fallback and parse for `Python 3.x`), and `rg --version`.
+
+### Detect `python3`
+
+```bash
+python3 --version 2>/dev/null || python --version 2>/dev/null
+```
+
+If neither prints `Python 3.x` (>=3.10), surface platform-appropriate guidance and continue:
+
+- **macOS** — install from [python.org/downloads](https://www.python.org/downloads/) (the "Python 3.x macOS 64-bit installer") or, if the user already uses Homebrew, `brew install python`. Avoid pyenv-built Python where possible — its bundled SQLite often has extension loading disabled, which the query engine handles gracefully but the user may want to know.
+- **Linux** — distro package manager: `sudo apt install python3 python3-venv` (Debian/Ubuntu), `sudo dnf install python3 python3-venv` (Fedora/RHEL), `sudo pacman -S python` (Arch). Tell the user the exact command for their distro.
+- **Windows** — install from [python.org/downloads](https://www.python.org/downloads/) (check "Add python.exe to PATH" during install) or via Microsoft Store.
+
+**Do not block setup** if `python3` is missing. Note the limitation, continue, and Step 8.5 will gracefully fall back to a lexical-only vault until the user installs Python and re-runs the provisioning step.
+
+### Detect `rg` (ripgrep)
+
+```bash
+rg --version 2>/dev/null
+```
+
+If absent, surface guidance — the lexical path still works (the script falls back to `grep` on POSIX or a pure-Python walker on Windows when neither is found):
+
+- **macOS** — `brew install ripgrep`, or download a release binary from [github.com/BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep)
+- **Linux** — `sudo apt install ripgrep` / `sudo dnf install ripgrep` / `sudo pacman -S ripgrep`
+- **Windows** — `winget install BurntSushi.ripgrep.MSVC`, `scoop install ripgrep`, or release binary
+
+**Do not block.** Setup continues either way.
+
+### After surfacing guidance
+
+Ask:
+
+> "Install these now and let me know when ready, or proceed with what's available?"
+
+If the user installs and confirms, re-run detection and continue. If they proceed without, record the limitation in the vault's CLAUDE.md `## Query engine` section (Step 8.5 writes that section) so the user can fix it later.
 
 ---
 
@@ -380,6 +426,43 @@ cd VAULT_PATH && git add CLAUDE.md && git commit -m "register: notion companion 
 
 ---
 
+## Step 8.5: Provision the query engine
+
+Hand off to the `mcbrain-ops` skill to create `<vault>/.mcbrain/`, install the per-vault Python venv, copy in the indexer script, patch the vault's `CLAUDE.md` so future operations route through the engine, and build the initial (empty) index. Everything that needs to happen end-to-end is encapsulated in the `migrate` subcommand — this step should not reimplement any of it.
+
+If Step 5.5 reported `python3` is missing, **skip Step 8.5** and tell the user: *"Skipping query-engine provisioning — Python 3 not found. Install Python (see Step 5.5 instructions) and re-run `mcbrain-ops migrate --vault <vault>` to provision the engine. Until then, the wiki is searchable lexically only."* The vault remains fully usable in lexical-only mode.
+
+Otherwise, run from the agent's environment (system shell, not the vault MCP):
+
+```bash
+python3 <plugin_root>/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py migrate --vault VAULT_PATH
+```
+
+What `migrate` does (do not duplicate this logic here — it lives in `mcbrain-ops`):
+
+1. Creates `VAULT_PATH/.mcbrain/{venv,bin}/`.
+2. Runs `python3 -m venv .mcbrain/venv`.
+3. Installs the pinned requirements (`fastembed`, `numpy`) into the venv via `pip`. **Never installed system-wide** — locked decision #11.
+4. Copies `mcbrain_ops.py` and `schema.sql` from this repo's `mcbrain-ops/references/` into `VAULT_PATH/.mcbrain/bin/`. The bin directory is tracked in git so the script travels with the vault.
+5. Patches `VAULT_PATH/CLAUDE.md` to add the `## Query engine` section, rewrite the `## Operations → Query` procedure to call this skill, and append `index sync` to the ingest procedure. The patch is **idempotent** — re-running it on an already-migrated vault is a no-op.
+6. Runs an initial `index rebuild` to seed the database. On a freshly created vault `wiki/` is empty, so this is a quick no-op that just timestamps the meta table.
+
+Surface the migrate output to the user — first-run downloads the FastEmbed embedding model (~30 MB) into the shared cache at `~/.cache/fastembed/`, and that download surprises users on metered connections if they don't see it announced.
+
+**Cross-platform notes** (the script handles these — listed here so the agent knows what's happening):
+
+- POSIX path to the venv interpreter: `<vault>/.mcbrain/venv/bin/python`.
+- Windows: `<vault>/.mcbrain/venv/Scripts/python.exe`. The script picks the right one based on `platform.system()`.
+- The model cache lives in FastEmbed's default location (`~/.cache/fastembed/` on POSIX, `%LOCALAPPDATA%\fastembed\` on Windows) and is **shared across all McBrain vaults** so additional vaults are essentially free to set up.
+
+**Commit (Git strategy only).** If the backup strategy is git, present a copy-paste block (do not run git directly):
+
+```bash
+cd VAULT_PATH && git add .mcbrain/bin CLAUDE.md && git commit -m "init: provision query engine" && git push
+```
+
+---
+
 ## Step 9: Install the companion operating skill
 
 Point the user at the `mcbrain` skill for day-to-day ingest/query/lint operations. It uses the `MCP_NAME` convention to route requests to the right vault — so "find insights from McBrain AI Science" maps to the `mcbrain-ai-science` MCP automatically.
@@ -410,6 +493,12 @@ Claude will read the source, discuss key points, write wiki pages in `wiki/`, up
 **Query**: `"Ask McBrain: [question]. Cite the pages you used."`
 **Lint**: `"Lint McBrain. Find contradictions, orphan pages, stale claims, missing cross-references."`
 **Save a query answer**: `"File your answer as a new wiki page at wiki/[topic].md"`
+
+**Query-engine maintenance** (rare — the index normally stays current automatically because every wiki write runs `index sync`):
+
+- *Full reindex* if the embedding model or schema changes, or if results stop making sense: `mcbrain-ops index rebuild` (or directly, `python3 <vault>/.mcbrain/bin/mcbrain_ops.py index rebuild --vault <vault>`).
+- *Index health check*: `mcbrain-ops index status` — prints doc count, last sync time, and the active embedding model.
+- *Remove the engine entirely*: `mcbrain-ops uninstall --force` — deletes `<vault>/.mcbrain/`. Wiki and raw content are untouched.
 
 ---
 

--- a/plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md
+++ b/plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md
@@ -111,6 +111,7 @@ Use when the user says "ingest" with no Notion context, or names a file already 
 5. Create or update entity and concept pages touched by this source.
 6. Update `wiki/index.md` with the new page(s).
 7. Append to `wiki/log.md`: `## [YYYY-MM-DD] ingest | [source title]`.
+8. Invoke the `mcbrain-ops` skill (`index sync`) so the new wiki page(s) are searchable immediately. Cheap (sub-second on no-op).
 
 A single source may touch 5-15 wiki pages. That's normal.
 
@@ -140,13 +141,16 @@ Use when the user has just finished a `notion-research-runner` pass, or referenc
 4. **Run the standard wiki-update steps** (steps 2–7 of *Ingest from raw/* above) against the new `raw/notes/<slug>.md` files. Cite them in wiki pages exactly the same way you'd cite any other raw source.
 5. **Close the loop in Notion.** After the wiki write succeeds, flip the Notion task's Status to `Done`. If the wiki write failed for a task, leave the Notion status at `In progress` and surface the error so the user can retry.
 6. Append to `wiki/log.md`: `## [YYYY-MM-DD] ingest (notion) | <tracker> — <N> tasks`.
+7. Invoke the `mcbrain-ops` skill (`index sync`) so the new wiki page(s) are searchable immediately.
 
 ### Query
 When asked a question against the wiki:
-1. Read `wiki/index.md` to find relevant pages
-2. Read those pages
-3. Synthesize an answer with citations (e.g., `[[wiki/topic]]`)
-4. Offer to file the answer as a new wiki page if it's worth keeping
+1. Invoke the `mcbrain-ops` skill (`query "<text>"`). It returns a ranked list of wiki page paths + scores as JSON, fused from lexical (ripgrep) and semantic (FastEmbed) search via Reciprocal Rank Fusion.
+2. Read the top 5–8 pages from that list.
+3. Synthesize an answer with `[[wikilinks]]` citations.
+4. Offer to file the answer as a new wiki page if it's worth keeping.
+
+`wiki/index.md` is no longer the retrieval mechanism — it stays for human browsing and lint only.
 
 Answers don't have to be prose. Pick the format that fits the question:
 - **Markdown page** — the default; file-able back into the wiki as a new synthesis page
@@ -215,6 +219,17 @@ Each log entry:
 One-line description of what was done.
 Files touched: wiki/page1.md, wiki/page2.md
 ```
+
+## Query engine
+
+- mode: lexical+semantic
+- embedding_model: BAAI/bge-small-en-v1.5
+- embedding_dim: 384
+- index_path: .mcbrain/index.db
+
+The query engine is hybrid: lexical (ripgrep / grep / pure-Python fallback) plus semantic (FastEmbed for embeddings, brute-force cosine via numpy over a SQLite-stored embedding column). Results from the two modalities are fused via Reciprocal Rank Fusion. The per-vault index lives at `.mcbrain/index.db` and is provisioned and maintained by the `mcbrain-ops` skill. Re-index with `mcbrain-ops index rebuild` if the schema or model ever changes.
+
+If this section is missing on an older vault, the `mcbrain` skill detects it on next invocation and offers to migrate the vault by running `mcbrain-ops migrate`.
 
 ## Notion companion databases
 

--- a/plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md
+++ b/plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md
@@ -96,6 +96,8 @@ Link to related concepts using [[wikilinks]] throughout the text.
 
 ## Operations
 
+**Always sync the search index after any wiki write.** Whenever you create, modify, or delete a file under `wiki/` — whether through a formal ingest, a lint pass that updates `log.md`, an ad-hoc page update, or a synthesis filing — invoke the `mcbrain-ops` skill (`index sync`) afterward so subsequent queries see the change. Cheap (sub-second on no-op). The specific operation procedures below all end with this step explicitly; this paragraph is the catch-all for anything not enumerated.
+
 ### Ingest
 
 "Ingest" has two modes. The `mcbrain` skill picks one based on conversation context (see its routing section). Both modes ultimately funnel through the same wiki-update steps below — the difference is where the source comes from.

--- a/plugins/mcbrain/skills/mcbrain/README.md
+++ b/plugins/mcbrain/skills/mcbrain/README.md
@@ -17,6 +17,8 @@ This is the **operating skill** — it runs day-to-day against an already-config
 - **Lint** — find contradictions, orphan pages, stale claims, and missing cross-references
 - **Synthesis** — file a new wiki page that merges insights across existing pages
 
+The query engine itself (hybrid lexical + semantic search) is the [`mcbrain-ops`](../mcbrain-ops) skill, provisioned automatically by [`mcbrain-setup`](../mcbrain-setup) and called automatically by this skill after wiki edits and at query time. If the vault was set up before the engine landed, this skill detects that and offers to migrate.
+
 On every operation it updates `wiki/index.md` and appends to `wiki/log.md`, and — when the vault is backed by git — offers to commit and push.
 
 ## How it works

--- a/plugins/mcbrain/skills/mcbrain/SKILL.md
+++ b/plugins/mcbrain/skills/mcbrain/SKILL.md
@@ -38,6 +38,31 @@ Follow what CLAUDE.md says — this skill is the trigger and the router, but CLA
 
 If `CLAUDE.md` is missing or unreadable, stop and tell the user — something is wrong with the MCP setup.
 
+## Step 2.5: Migration check (query engine)
+
+Before doing any procedural work, verify the vault has the query engine provisioned. This is the **only** orchestration concern this skill owns for the query engine — all the actual query and indexing procedures live in CLAUDE.md (rewritten by `mcbrain-ops migrate` to delegate into the `mcbrain-ops` skill).
+
+Check both:
+
+1. The vault has a `.mcbrain/` directory (with `bin/mcbrain_ops.py` inside). The vault MCP can confirm via a directory listing.
+2. The `CLAUDE.md` you just read contains a `## Query engine` section.
+
+If **either is missing**, the vault was set up before the query engine landed. Offer the user a one-shot migration:
+
+> "This vault was set up before the query engine landed. Want me to upgrade it now? This creates `<vault>/.mcbrain/`, installs the indexer dependencies into a per-vault Python venv, builds the initial search index, and updates this vault's `CLAUDE.md`. Takes about a minute, ~30 MB model download the first time across all your McBrains. Existing wiki pages aren't touched."
+
+On accept, run from the agent's environment (system shell, not the vault MCP — the migrate command needs to create files outside the MCP root and shell out to `pip`):
+
+```bash
+python3 <plugin_root>/plugins/mcbrain/skills/mcbrain-ops/references/mcbrain_ops.py migrate --vault <vault_path>
+```
+
+Surface the output. After migration completes, **re-read `CLAUDE.md`** (it has been patched) and proceed with the user's original request using the now-updated procedure.
+
+If the user declines migration, continue in lexical-only fallback mode: the `mcbrain-ops query` invocation in CLAUDE.md will still work (it falls back to ripgrep when no index is provisioned) but with reduced recall on paraphrased questions. Let the user know that's what's happening and that they can run migration any time.
+
+**Architectural principle (do not violate):** procedures (how to query, when to sync the index, how to ingest) live in CLAUDE.md. This skill is a router — it catches intent, routes to the right vault, runs the migration check, then defers to CLAUDE.md. Do not add query routing logic, post-edit `index sync` orchestration, or any other procedural step to this skill — they belong in CLAUDE.md and `mcbrain-ops` respectively.
+
 ## Why this two-layer design
 
 McBrain is a living document. Its conventions evolve as the user refines them, and CLAUDE.md is checked into the vault so those conventions travel with the knowledge base. Hardcoding the schema into this skill would mean two places to keep in sync. Instead: this skill catches the user's intent, routes to the right vault, and defers to CLAUDE.md for the spec.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,54 @@
+# Tests
+
+Pytest suite for the `mcbrain-ops` query engine, organized following Kent C. Dodds' [Testing Trophy](https://kentcdodds.com/blog/the-testing-trophy-and-testing-classifications):
+
+| File | Tier | What it covers |
+|---|---|---|
+| `test_static.py` | Static / smoke | Module imports, `--help` lists every subcommand, regression-grep for the no-unbounded-text-SELECT contract |
+| `test_unit.py` | Unit | Pure-Python logic: RRF math, excerpt rendering, hashing, cross-platform paths, blob round-trip |
+| `test_patcher.py` | Unit | CLAUDE.md text-manipulation helpers (this is the most fragile region — covered exhaustively) |
+| `test_index.py` | Integration | Real SQLite DB + real FastEmbed embedder: init, rebuild, sync (add/change/delete), status, model-compatibility check |
+| `test_search.py` | Integration | Lexical cascade (rg / grep / Python fallback), semantic recall on paraphrased queries, hybrid query, lazy-text-fetch regression |
+| `test_e2e.py` | E2E | Full lifecycle through the script's CLI: status → query × 3 → sync → query → uninstall |
+
+The bulk of the tests are in the integration tier — that's where the trophy says investment pays best.
+
+## Running
+
+The tests need fastembed, numpy, and pytest installed in the same Python that runs them. Easiest setup is a dedicated test venv:
+
+```sh
+# From the repo root
+python3 -m venv .test-venv
+.test-venv/bin/pip install \
+  -r plugins/mcbrain/skills/mcbrain-ops/references/requirements.txt \
+  -r tests/requirements.txt
+
+.test-venv/bin/python -m pytest tests/ -v
+```
+
+First run downloads the FastEmbed model (~30 MB) into `~/.cache/fastembed/`. Subsequent runs reuse it.
+
+## Speed
+
+The model load is the dominant cost. The `shared_embedder` fixture is session-scoped, so the model is loaded exactly once across all integration and e2e tests. A clean run is ~10–20 seconds on a laptop after the model is cached.
+
+Unit tests (`test_static.py`, `test_unit.py`, `test_patcher.py`) don't touch fastembed at all and complete in under a second.
+
+To run only the fast tier:
+
+```sh
+.test-venv/bin/python -m pytest tests/test_static.py tests/test_unit.py tests/test_patcher.py -v
+```
+
+## Fixtures
+
+- `tests/fixtures/wiki/*.md` — four sample wiki pages (myocardial-infarction, scaling-laws, sourdough, photosynthesis) chosen so semantic queries with zero lexical overlap have an unambiguous expected top-1
+- `tests/fixtures/claude_md_legacy.md` — a CLAUDE.md without `## Query engine`, used to test the migration patcher
+- `tests/fixtures/claude_md_h4_after_query.md` — the H4-after-Query edge case that exposed an early bug in the section-end finder
+
+## What's deliberately NOT tested
+
+- **Cross-platform Windows behavior end-to-end.** The unit tests cover the path-construction logic via mocking, but a true Windows run requires Windows. Consider a CI matrix if/when McBrain has Windows users.
+- **The full `migrate` subcommand including `python -m venv` + `pip install`.** That path requires network and ~30 seconds; the integration tests skip the bootstrap and test the post-bootstrap behavior directly. The static tests verify the migrate help works.
+- **Claude Desktop integration.** The skill is invoked by Claude through Bash; that side of the contract isn't covered here and is verified by manual smoke against a real vault.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,102 @@
+"""Shared pytest fixtures for the mcbrain-ops test suite.
+
+Design notes:
+
+- The script under test (`mcbrain_ops.py`) lives at
+  `plugins/mcbrain/skills/mcbrain-ops/references/`. We add that directory to
+  sys.path so tests can `import mcbrain_ops` directly without installing it
+  as a package.
+- `mcbrain_ops` does lazy imports of fastembed/numpy inside subcommand
+  handlers, so `import mcbrain_ops` succeeds even in a Python without those
+  deps. Unit tests that exercise pure-Python logic don't need them.
+- Integration tests that exercise indexing/search DO need fastembed + numpy
+  in the test runner's Python. The session-scoped `shared_embedder` fixture
+  loads the FastEmbed model exactly once per test session — the model load
+  is the dominant cost (~500 ms), so amortizing it matters.
+- Fastembed's model weights are cached at `~/.cache/fastembed/` (the library
+  default). Re-running the suite is fast after the first run.
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = (
+    REPO_ROOT / "plugins" / "mcbrain" / "skills" / "mcbrain-ops" / "references"
+)
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+# Make `import mcbrain_ops` work in every test module.
+sys.path.insert(0, str(SCRIPT_DIR))
+
+
+@pytest.fixture(scope="session")
+def script_dir() -> Path:
+    """Directory containing mcbrain_ops.py and its sibling reference files."""
+    return SCRIPT_DIR
+
+
+@pytest.fixture(scope="session")
+def fixtures_dir() -> Path:
+    """Directory holding test input markdown files."""
+    return FIXTURES_DIR
+
+
+@pytest.fixture
+def fresh_vault(tmp_path: Path) -> Path:
+    """A vault with sample wiki content + a legacy CLAUDE.md, NO .mcbrain/.
+
+    Use this for tests that need a clean slate (e.g., migrate testing,
+    no-index fallback testing).
+    """
+    vault = tmp_path / "vault"
+    (vault / "wiki").mkdir(parents=True)
+    for md in (FIXTURES_DIR / "wiki").glob("*.md"):
+        shutil.copy(md, vault / "wiki" / md.name)
+    (vault / "CLAUDE.md").write_text(
+        (FIXTURES_DIR / "claude_md_legacy.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    return vault
+
+
+@pytest.fixture
+def vault_with_schema(fresh_vault: Path) -> Path:
+    """fresh_vault + .mcbrain/bin/schema.sql in place but no DB yet.
+
+    Use this for tests that exercise index init / rebuild / sync directly
+    without going through the full migrate (which would create a venv and
+    pip-install — too slow for unit-grade tests).
+    """
+    bin_dir = fresh_vault / ".mcbrain" / "bin"
+    bin_dir.mkdir(parents=True)
+    shutil.copy(SCRIPT_DIR / "schema.sql", bin_dir / "schema.sql")
+    return fresh_vault
+
+
+@pytest.fixture(scope="session")
+def shared_embedder():
+    """Session-scoped FastEmbed instance.
+
+    The first call to mcbrain_ops.get_embedder() triggers the model download
+    (if not already cached) and instantiation. Subsequent calls during the
+    same session reuse the cached singleton inside the module.
+    """
+    pytest.importorskip("fastembed")
+    pytest.importorskip("numpy")
+    import mcbrain_ops
+
+    return mcbrain_ops.get_embedder()
+
+
+@pytest.fixture
+def populated_vault(vault_with_schema: Path, shared_embedder) -> Path:
+    """vault_with_schema with a fresh index built from the wiki content."""
+    import mcbrain_ops
+
+    mcbrain_ops.cmd_rebuild(vault_with_schema)
+    return vault_with_schema

--- a/tests/fixtures/claude_md_h4_after_query.md
+++ b/tests/fixtures/claude_md_h4_after_query.md
@@ -1,0 +1,16 @@
+# CLAUDE.md — Edge case
+
+The Query section is followed immediately by an H4 subsection (`#### Notes`) rather than a sibling H3. The naive section-end detector would swallow the H4. The patcher must stop at any heading.
+
+## Operations
+
+### Query
+When asked a question against the wiki:
+1. Read `wiki/index.md` to find relevant pages
+2. Synthesize an answer with citations.
+
+#### Notes about the Query operation
+This subsection must survive the patcher.
+
+### Lint
+1. Lint wiki.

--- a/tests/fixtures/claude_md_legacy.md
+++ b/tests/fixtures/claude_md_legacy.md
@@ -1,0 +1,35 @@
+# CLAUDE.md — Test Vault
+
+A vault that pre-dates the McBrain query engine. The patcher should rewrite the Query operation to delegate to mcbrain-ops, append an index sync step to the Ingest procedure, and append a section that records the active engine configuration.
+
+## Operations
+
+### Ingest
+
+#### Ingest from raw/
+
+1. Read each source file in full.
+2. Discuss key takeaways.
+3. Write or update a wiki page.
+4. Update `wiki/index.md`.
+5. Append to `wiki/log.md`.
+6. Done.
+
+#### Ingest from Notion research tracker
+
+1. Pull tasks.
+2. File them.
+
+### Query
+When asked a question against the wiki:
+1. Read `wiki/index.md` to find relevant pages
+2. Read those pages
+3. Synthesize an answer with citations.
+
+### Lint
+1. Sample wiki pages.
+2. Report issues.
+
+## Backup
+
+Strategy: none.

--- a/tests/fixtures/wiki/myocardial-infarction.md
+++ b/tests/fixtures/wiki/myocardial-infarction.md
@@ -1,0 +1,3 @@
+# Myocardial Infarction
+
+A heart attack occurs when blood flow to the heart muscle is blocked. Common cause: coronary artery disease.

--- a/tests/fixtures/wiki/photosynthesis.md
+++ b/tests/fixtures/wiki/photosynthesis.md
@@ -1,0 +1,3 @@
+# Photosynthesis
+
+Plants convert light energy into chemical energy stored in glucose. Chlorophyll absorbs light in the visible spectrum.

--- a/tests/fixtures/wiki/scaling-laws.md
+++ b/tests/fixtures/wiki/scaling-laws.md
@@ -1,0 +1,3 @@
+# Scaling Laws
+
+Neural network performance improves predictably with model size, dataset size, and compute. Chinchilla-optimal training balances parameter count and tokens.

--- a/tests/fixtures/wiki/sourdough.md
+++ b/tests/fixtures/wiki/sourdough.md
@@ -1,0 +1,3 @@
+# Sourdough Bread
+
+Wild yeast and lactobacillus cultures ferment dough over many hours, producing characteristic flavor and structure.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+# Test dependencies. Install on top of mcbrain-ops/references/requirements.txt
+# (which provides fastembed + numpy).
+pytest>=8.0,<9

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,137 @@
+"""End-to-end test — full lifecycle exercised through the script's CLI.
+
+Calls the script via `python -m` style subprocess invocation so we get
+the same code path a real user (and the `mcbrain-setup` skill) would take.
+We skip the part of `migrate` that creates a venv and pip-installs (too slow
+and requires network); the test runner's Python is assumed to already have
+fastembed + numpy. The migration logic that DOES get exercised: copying
+reference files, patching CLAUDE.md, building the initial index.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def run_cli(script_path: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(script_path), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def cli_vault(fresh_vault: Path, script_dir: Path) -> Path:
+    """A vault prepared like a real provisioned one: CLAUDE.md patched,
+    .mcbrain/bin/ populated, index.db rebuilt. Skips the venv-creation and
+    pip-install steps of migrate to keep the test fast — the test runner's
+    Python is already serving as the 'venv' here."""
+    bin_dir = fresh_vault / ".mcbrain" / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(script_dir / "mcbrain_ops.py", bin_dir / "mcbrain_ops.py")
+    shutil.copy(script_dir / "schema.sql", bin_dir / "schema.sql")
+
+    # Patch CLAUDE.md and seed the index by calling the underlying functions
+    # directly from the test runner — equivalent to what the venv-resident
+    # script would do, just without the subprocess hop.
+    import mcbrain_ops as ops
+
+    ops.patch_claude_md(fresh_vault)
+    ops.cmd_rebuild(fresh_vault)
+    return fresh_vault
+
+
+def test_e2e_status_query_uninstall(cli_vault: Path, script_dir: Path, shared_embedder):
+    """Full lifecycle from the CLI: status → multiple queries → uninstall."""
+    script = script_dir / "mcbrain_ops.py"
+
+    # 1. Status — provisioned, doc count matches fixture wiki count.
+    result = run_cli(script, "index", "status", "--vault", str(cli_vault))
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["provisioned"] is True
+    assert payload["doc_count"] == 4
+
+    # 2. Three queries that each have a distinct expected top-1.
+    expectations = [
+        ("heart attack", "wiki/myocardial-infarction.md"),  # lexical winner
+        ("cardiac event", "wiki/myocardial-infarction.md"),  # pure semantic
+        ("how plants make food", "wiki/photosynthesis.md"),  # paraphrase
+    ]
+    for query_text, expected_top in expectations:
+        result = run_cli(
+            script, "query", query_text, "--k", "3", "--vault", str(cli_vault)
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["mode"] == "lexical+semantic"
+        assert payload["results"][0]["path"] == expected_top, (
+            f"query {query_text!r}: expected top-1 {expected_top}, "
+            f"got {payload['results'][0]['path']}"
+        )
+
+    # 3. Uninstall (dry-run first) reports what would be deleted but doesn't.
+    mcbrain_dir = cli_vault / ".mcbrain"
+    result = run_cli(script, "uninstall", "--vault", str(cli_vault))
+    assert result.returncode == 0
+    assert "would remove" in result.stderr
+    assert mcbrain_dir.exists()  # dry-run: still here
+
+    # 4. Uninstall --force actually removes .mcbrain/, leaves wiki/CLAUDE.md alone.
+    wiki = cli_vault / "wiki"
+    cmd = cli_vault / "CLAUDE.md"
+    wiki_files_before = sorted(p.name for p in wiki.glob("*.md"))
+    cmd_size_before = cmd.stat().st_size
+
+    result = run_cli(script, "uninstall", "--force", "--vault", str(cli_vault))
+    assert result.returncode == 0
+    assert "removed" in result.stderr
+    assert not mcbrain_dir.exists()
+    assert sorted(p.name for p in wiki.glob("*.md")) == wiki_files_before
+    assert cmd.stat().st_size == cmd_size_before
+
+
+def test_e2e_query_after_sync_picks_up_new_file(cli_vault: Path, script_dir: Path):
+    """Add a wiki file, run sync, query for it — the new file should rank."""
+    script = script_dir / "mcbrain_ops.py"
+    new_page = cli_vault / "wiki" / "quantum-entanglement.md"
+    new_page.write_text(
+        "# Quantum Entanglement\n\nTwo particles share a state — measuring one "
+        "instantly determines the other regardless of distance.\n",
+        encoding="utf-8",
+    )
+
+    result = run_cli(script, "index", "sync", "--vault", str(cli_vault))
+    assert result.returncode == 0, result.stderr
+
+    result = run_cli(
+        script,
+        "query",
+        "spooky action at a distance",
+        "--k",
+        "1",
+        "--vault",
+        str(cli_vault),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["results"][0]["path"] == "wiki/quantum-entanglement.md"
+
+
+def test_e2e_missing_vault_arg_exits_with_clear_error(script_dir: Path):
+    """No --vault and no MCBRAIN_VAULT → exit 2 with a clear message."""
+    script = script_dir / "mcbrain_ops.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "index", "status"],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin"},  # strip MCBRAIN_VAULT
+    )
+    assert result.returncode == 2
+    assert "vault" in result.stderr.lower()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,232 @@
+"""Integration tests for the index lifecycle: init, rebuild, sync, status.
+
+Uses the session-scoped FastEmbed fixture so model load is paid once.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+import mcbrain_ops as ops
+
+
+# ----------------------------- init / rebuild ------------------------------
+
+
+def test_init_db_creates_tables_and_meta(vault_with_schema: Path):
+    """init_db writes both tables and seeds the meta row."""
+    db_path = ops.index_db_path(vault_with_schema)
+    schema_sql = vault_with_schema / ".mcbrain" / "bin" / "schema.sql"
+    ops.init_db(db_path, schema_sql)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "chunks" in names
+        assert "meta" in names
+
+        meta = dict(conn.execute("SELECT key, value FROM meta").fetchall())
+        assert meta["embedding_model"] == ops.EMBEDDING_MODEL
+        assert meta["embedding_dim"] == str(ops.EMBEDDING_DIM)
+        assert meta["schema_version"] == ops.SCHEMA_VERSION
+    finally:
+        conn.close()
+
+
+def test_rebuild_empty_vault(vault_with_schema: Path, shared_embedder):
+    """A vault with no wiki/ files still produces a valid empty index."""
+    # Wipe the wiki so it's empty.
+    for p in (vault_with_schema / "wiki").glob("*.md"):
+        p.unlink()
+
+    rc = ops.cmd_rebuild(vault_with_schema)
+    assert rc == 0
+
+    db = ops.index_db_path(vault_with_schema)
+    assert db.exists()
+    conn = sqlite3.connect(db)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        assert n == 0
+    finally:
+        conn.close()
+
+
+def test_rebuild_populates_chunks(populated_vault: Path):
+    """Rebuild against the four fixture wiki pages → 4 rows."""
+    db = ops.index_db_path(populated_vault)
+    conn = sqlite3.connect(db)
+    try:
+        rows = conn.execute("SELECT path, length(embedding) FROM chunks").fetchall()
+        assert len(rows) == 4
+        # 384 float32s = 1536 bytes per row.
+        for path, embedding_len in rows:
+            assert embedding_len == 384 * 4, f"unexpected embedding size for {path}"
+    finally:
+        conn.close()
+
+
+def test_rebuild_idempotent(populated_vault: Path):
+    """Running rebuild a second time produces the same chunk count and
+    advances last_rebuild."""
+    rc = ops.cmd_rebuild(populated_vault)
+    assert rc == 0
+    db = ops.index_db_path(populated_vault)
+    conn = sqlite3.connect(db)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        assert n == 4
+    finally:
+        conn.close()
+
+
+# ----------------------------- sync (incremental) --------------------------
+
+
+def test_sync_no_op_after_rebuild(populated_vault: Path, capsys):
+    """Sync immediately after rebuild reports 0 changes and 4 total."""
+    rc = ops.cmd_sync(populated_vault)
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "added=0" in err
+    assert "changed=0" in err
+    assert "removed=0" in err
+    assert "total=4" in err
+
+
+def test_sync_detects_added_file(populated_vault: Path):
+    """Adding a new wiki file is picked up incrementally."""
+    new = populated_vault / "wiki" / "new-page.md"
+    new.write_text("# New page\n\nA freshly added topic.\n", encoding="utf-8")
+
+    rc = ops.cmd_sync(populated_vault)
+    assert rc == 0
+
+    conn = sqlite3.connect(ops.index_db_path(populated_vault))
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        assert n == 5
+        paths = {row[0] for row in conn.execute("SELECT path FROM chunks").fetchall()}
+        assert "wiki/new-page.md" in paths
+    finally:
+        conn.close()
+
+
+def test_sync_detects_modified_file(populated_vault: Path):
+    """Modifying a file changes its hash → re-embed."""
+    target = populated_vault / "wiki" / "sourdough.md"
+    original_hash = ops.hash_file(target)
+
+    target.write_text(
+        "# Sourdough Bread\n\nCompletely rewritten content about something else "
+        "entirely — wild fermentation isn't actually sourdough's defining feature.\n",
+        encoding="utf-8",
+    )
+    new_hash = ops.hash_file(target)
+    assert original_hash != new_hash
+
+    rc = ops.cmd_sync(populated_vault)
+    assert rc == 0
+
+    conn = sqlite3.connect(ops.index_db_path(populated_vault))
+    try:
+        stored_hash = conn.execute(
+            "SELECT content_hash FROM chunks WHERE path = ?", ("wiki/sourdough.md",)
+        ).fetchone()[0]
+        assert stored_hash == new_hash
+    finally:
+        conn.close()
+
+
+def test_sync_detects_deleted_file(populated_vault: Path):
+    """Deleting a wiki file removes it from the index on next sync."""
+    (populated_vault / "wiki" / "sourdough.md").unlink()
+    rc = ops.cmd_sync(populated_vault)
+    assert rc == 0
+
+    conn = sqlite3.connect(ops.index_db_path(populated_vault))
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        assert n == 3
+        paths = {row[0] for row in conn.execute("SELECT path FROM chunks").fetchall()}
+        assert "wiki/sourdough.md" not in paths
+    finally:
+        conn.close()
+
+
+def test_sync_initializes_db_when_missing(vault_with_schema: Path, shared_embedder):
+    """sync should bootstrap the DB if it doesn't exist yet (it can be the
+    first index-building call after a partial migrate)."""
+    assert not ops.index_db_path(vault_with_schema).exists()
+    rc = ops.cmd_sync(vault_with_schema)
+    assert rc == 0
+    assert ops.index_db_path(vault_with_schema).exists()
+    conn = sqlite3.connect(ops.index_db_path(vault_with_schema))
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        assert n == 4
+    finally:
+        conn.close()
+
+
+# ----------------------------- status ---------------------------------------
+
+
+def test_status_unprovisioned(fresh_vault: Path, capsys):
+    """A vault without .mcbrain/index.db reports provisioned=false."""
+    rc = ops.cmd_status(fresh_vault)
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["provisioned"] is False
+    assert payload["index_path"].endswith("/.mcbrain/index.db")
+
+
+def test_status_populated(populated_vault: Path, capsys):
+    """Status JSON shape matches what callers depend on."""
+    rc = ops.cmd_status(populated_vault)
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+
+    assert payload["provisioned"] is True
+    assert payload["doc_count"] == 4
+    assert payload["embedding_model"] == ops.EMBEDDING_MODEL
+    assert payload["embedding_dim"] == ops.EMBEDDING_DIM
+    assert payload["schema_version"] == "1"
+    assert payload["last_sync"]
+    assert payload["last_rebuild"]
+    assert payload["index_size_bytes"] > 0
+
+
+# ----------------------------- model compatibility -------------------------
+
+
+def test_check_model_compatibility_dies_on_dim_mismatch(populated_vault: Path):
+    """If the stored dim differs from the running code's, abort and tell the
+    user to rebuild."""
+    conn = sqlite3.connect(ops.index_db_path(populated_vault))
+    try:
+        conn.execute("UPDATE meta SET value = '999' WHERE key = 'embedding_dim'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Re-open via open_db (which is what subcommands use) and call the check.
+    conn = ops.open_db(populated_vault)
+    try:
+        with pytest.raises(SystemExit) as exc:
+            ops.check_model_compatibility(conn, populated_vault)
+        assert exc.value.code == 6
+    finally:
+        conn.close()

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -194,3 +194,50 @@ def test_replace_query_section_no_op_when_already_migrated():
 def test_replace_query_section_no_op_when_no_query_block():
     text = "## Operations\n\n### Lint\nfoo\n"
     assert ops._replace_query_section(text) == text
+
+
+# ------------------------- general sync rule (catch-all) --------------------
+
+
+def test_general_sync_rule_inserted_under_operations(fresh_vault: Path):
+    """patch_claude_md must add the 'always sync after any wiki write' rule
+    immediately under ## Operations (regression for bead McBrain-bf3:
+    without this catch-all rule, Claude only syncs after the formally
+    enumerated ingest procedures, leaving lint and ad-hoc edits to drift)."""
+    ops.patch_claude_md(fresh_vault)
+    after = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+    assert ops.GENERAL_SYNC_RULE_MARKER in after
+    operations_idx = after.find("## Operations")
+    rule_idx = after.find(ops.GENERAL_SYNC_RULE_MARKER)
+    next_subhead = after.find("\n### ", operations_idx)
+    assert (
+        operations_idx < rule_idx < next_subhead
+    ), "rule must sit between '## Operations' and the first sub-heading"
+
+
+def test_general_sync_rule_idempotent(fresh_vault: Path):
+    """Re-running the patcher must not duplicate the catch-all rule."""
+    ops.patch_claude_md(fresh_vault)
+    ops.patch_claude_md(fresh_vault)
+    after = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+    assert after.count(ops.GENERAL_SYNC_RULE_MARKER) == 1
+
+
+def test_general_sync_rule_present_in_template(script_dir: Path):
+    """Regression: the template ships with the same rule the patcher would
+    add. Otherwise fresh-installed vaults and migrated vaults end up
+    structurally different in a meaningful way."""
+    template_path = (
+        script_dir.parent.parent
+        / "mcbrain-setup"
+        / "references"
+        / "claude-md-template.md"
+    )
+    assert template_path.is_file(), template_path
+    assert ops.GENERAL_SYNC_RULE_MARKER in template_path.read_text(encoding="utf-8")
+
+
+def test_general_sync_rule_no_op_without_operations_header():
+    """If a CLAUDE.md has no '## Operations' section, leave it alone."""
+    text = "# Just a title\n\nSome unrelated content.\n"
+    assert ops._ensure_general_sync_rule(text) == text

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -1,0 +1,196 @@
+"""Patcher tests — CLAUDE.md text manipulation.
+
+The CLAUDE.md patcher (`patch_claude_md` and helpers) is regex-heavy text
+mangling. The tests here are deliberately exhaustive because this is exactly
+the kind of code that breaks silently on inputs the implementer didn't
+anticipate.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import mcbrain_ops as ops
+
+
+# ------------------------- _find_next_heading -------------------------------
+
+
+def test_find_next_heading_h2():
+    text = "## Foo\n\nbody\n## Bar\n"
+    # Search starting from after "## Foo"
+    idx = ops._find_next_heading(text, len("## Foo"))
+    assert text[idx : idx + 7] == "## Bar\n"
+
+
+def test_find_next_heading_h4():
+    text = "## Foo\n\nbody\n#### Bar\n"
+    idx = ops._find_next_heading(text, len("## Foo"))
+    assert text[idx : idx + 9] == "#### Bar\n"
+
+
+def test_find_next_heading_at_eof():
+    """Returns len(text) when no further heading exists."""
+    text = "## Foo\n\nbody only, no further heading"
+    idx = ops._find_next_heading(text, len("## Foo"))
+    assert idx == len(text)
+
+
+def test_find_next_heading_skips_in_paragraph():
+    """A '#' that's not at the start of a line is not a heading."""
+    text = "## Foo\n\nA paragraph mentioning #hashtag inline.\n## Bar\n"
+    idx = ops._find_next_heading(text, len("## Foo"))
+    assert text[idx : idx + 7] == "## Bar\n"
+
+
+# ------------------------- patch_claude_md (legacy) -------------------------
+
+
+def test_patch_legacy_template_adds_query_engine_section(fresh_vault: Path):
+    """A vault without ## Query engine gets the section appended."""
+    cmd_path = fresh_vault / "CLAUDE.md"
+    assert "## Query engine" not in cmd_path.read_text(encoding="utf-8")
+
+    changed = ops.patch_claude_md(fresh_vault)
+    assert changed is True
+
+    after = cmd_path.read_text(encoding="utf-8")
+    assert "## Query engine" in after
+    assert "embedding_model: BAAI/bge-small-en-v1.5" in after
+    assert "embedding_dim: 384" in after
+    assert "index_path: .mcbrain/index.db" in after
+
+
+def test_patch_legacy_rewrites_query_operation(fresh_vault: Path):
+    """The legacy ### Query block is replaced with the mcbrain-ops version."""
+    ops.patch_claude_md(fresh_vault)
+    after = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+    # Old retrieval mechanism is gone.
+    assert "Read `wiki/index.md` to find relevant pages" not in after
+    # New delegation is in.
+    assert "Invoke the `mcbrain-ops` skill" in after
+    assert 'query "<text>"' in after
+
+
+def test_patch_preserves_lint_section(fresh_vault: Path):
+    """Replacing ### Query must not consume the following ### Lint sibling."""
+    ops.patch_claude_md(fresh_vault)
+    after = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "### Lint" in after
+    assert "Sample wiki pages" in after
+
+
+def test_patch_handles_h4_after_query(tmp_path: Path, fixtures_dir: Path):
+    """Regression: H4 (####) immediately following ### Query was being swallowed."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "CLAUDE.md").write_text(
+        (fixtures_dir / "claude_md_h4_after_query.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    ops.patch_claude_md(vault)
+    after = (vault / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "#### Notes about the Query operation" in after
+    assert "This subsection must survive the patcher." in after
+
+
+# ------------------------- patch_claude_md (idempotency) --------------------
+
+
+def test_patch_is_idempotent(fresh_vault: Path):
+    """Running the patcher twice is a no-op the second time."""
+    first_changed = ops.patch_claude_md(fresh_vault)
+    after_first = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+
+    second_changed = ops.patch_claude_md(fresh_vault)
+    after_second = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+
+    assert first_changed is True
+    assert second_changed is False
+    assert after_first == after_second
+
+
+def test_patch_skips_when_query_engine_present_and_query_already_rewritten(
+    fresh_vault: Path,
+):
+    """If an upgrade has already happened, second call returns False without
+    altering the file even by a whitespace."""
+    ops.patch_claude_md(fresh_vault)
+    snapshot = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+
+    changed = ops.patch_claude_md(fresh_vault)
+    assert changed is False
+    assert (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8") == snapshot
+
+
+# ------------------------- patch_claude_md (missing CLAUDE.md) --------------
+
+
+def test_patch_skips_silently_when_no_claude_md(tmp_path: Path):
+    """A vault with no CLAUDE.md returns False rather than crashing."""
+    vault = tmp_path / "no_cmd"
+    vault.mkdir()
+    assert ops.patch_claude_md(vault) is False
+
+
+# ------------------------- _ensure_index_sync_tail --------------------------
+
+
+def test_index_sync_tail_autonumbers_after_max(fresh_vault: Path):
+    """The new step is numbered max(existing) + 1."""
+    ops.patch_claude_md(fresh_vault)
+    after = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+    # The legacy fixture's Ingest from raw/ has steps 1..6, so the new step
+    # must be `7. Invoke the `mcbrain-ops` skill (`index sync`)...`
+    assert "7. Invoke the `mcbrain-ops` skill (`index sync`)" in after
+
+
+def test_index_sync_tail_skipped_if_already_present(fresh_vault: Path):
+    """Once the tail is in, a second pass leaves it alone."""
+    ops.patch_claude_md(fresh_vault)
+    after_first = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+    count_first = after_first.count("(`index sync`)")
+    ops.patch_claude_md(fresh_vault)
+    after_second = (fresh_vault / "CLAUDE.md").read_text(encoding="utf-8")
+    count_second = after_second.count("(`index sync`)")
+    assert count_first == count_second  # not duplicated
+
+
+def test_index_sync_tail_uses_bullet_when_no_numbered_list():
+    """If Ingest from raw/ doesn't have a numbered list, fall back to a bullet."""
+    text = (
+        "## Operations\n\n"
+        "#### Ingest from raw/\n\n"
+        "Just a paragraph, no numbered steps.\n\n"
+        "### Lint\nfoo\n"
+    )
+    out = ops._ensure_index_sync_tail(text)
+    # New line should be a hyphen-bullet, not a numbered step.
+    assert "- Invoke the `mcbrain-ops` skill" in out
+    assert "1. Invoke" not in out
+
+
+def test_index_sync_tail_no_op_when_section_missing():
+    """If there's no `#### Ingest from raw/` section at all, return text unchanged."""
+    text = "## Backup\n\nStrategy: none.\n"
+    assert ops._ensure_index_sync_tail(text) == text
+
+
+# ------------------------- _replace_query_section ---------------------------
+
+
+def test_replace_query_section_no_op_when_already_migrated():
+    """Already contains 'mcbrain-ops' inside the Query block? Skip."""
+    text = (
+        "## Operations\n\n"
+        "### Query\nInvoke the `mcbrain-ops` skill (`query`).\n\n"
+        "### Lint\nfoo\n"
+    )
+    assert ops._replace_query_section(text) == text
+
+
+def test_replace_query_section_no_op_when_no_query_block():
+    text = "## Operations\n\n### Lint\nfoo\n"
+    assert ops._replace_query_section(text) == text

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,210 @@
+"""Search behavior: lexical cascade, semantic recall, hybrid query, lazy fetch.
+
+The query subcommand is the user-facing center of the engine. These tests
+verify that:
+- The lexical cascade (rg → grep → pure-Python) is a fallback chain that
+  always produces results.
+- Semantic search recovers paraphrased queries that have zero lexical
+  overlap with the matching wiki page.
+- The hybrid query merges both modalities via RRF.
+- The lazy-text-fetch optimization (bead McBrain-rtp) still holds —
+  cmd_query must never SELECT all chunks' text upfront.
+- The no-index lexical fallback path still works.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+import mcbrain_ops as ops
+
+
+# ----------------------------- lexical cascade -----------------------------
+
+
+def test_lexical_search_finds_term_in_python_fallback(
+    fresh_vault: Path, monkeypatch
+):
+    """Force the pure-Python fallback by hiding rg and grep. Lexical results
+    should still come back."""
+    monkeypatch.setattr(ops.shutil, "which", lambda name: None)
+    results = ops.lexical_search(fresh_vault, "heart attack")
+    paths = [p for p, _ in results]
+    assert "wiki/myocardial-infarction.md" in paths
+
+
+def test_lexical_search_returns_empty_when_no_match(fresh_vault: Path):
+    results = ops.lexical_search(fresh_vault, "zzzzzz_no_such_string_zzzzz")
+    assert results == []
+
+
+def test_lexical_search_no_wiki_dir_returns_empty(tmp_path: Path):
+    """A vault without wiki/ should return [] cleanly, not raise."""
+    vault = tmp_path / "v"
+    vault.mkdir()
+    assert ops.lexical_search(vault, "anything") == []
+
+
+def test_lexical_search_ranks_by_hit_count(tmp_path: Path, monkeypatch):
+    """A page with two hits ranks above a page with one hit."""
+    monkeypatch.setattr(ops.shutil, "which", lambda name: None)
+    vault = tmp_path / "v"
+    (vault / "wiki").mkdir(parents=True)
+    (vault / "wiki" / "many.md").write_text("apple apple apple", encoding="utf-8")
+    (vault / "wiki" / "few.md").write_text("apple", encoding="utf-8")
+
+    results = ops.lexical_search(vault, "apple")
+    paths = [p for p, _ in results]
+    assert paths.index("wiki/many.md") < paths.index("wiki/few.md")
+
+
+# ----------------------------- semantic recall ------------------------------
+
+
+def test_semantic_finds_paraphrase(populated_vault: Path):
+    """'cardiac event' has zero lexical overlap with myocardial-infarction.md
+    but should still be the top semantic hit."""
+    conn = ops.open_db(populated_vault)
+    try:
+        results = ops.semantic_search(conn, "cardiac event")
+    finally:
+        conn.close()
+    assert results, "semantic search returned nothing"
+    top_path = results[0][0]
+    assert top_path == "wiki/myocardial-infarction.md"
+
+
+def test_semantic_finds_topic_via_synonyms(populated_vault: Path):
+    """'how plants make food' should surface photosynthesis.md."""
+    conn = ops.open_db(populated_vault)
+    try:
+        results = ops.semantic_search(conn, "how plants make food")
+    finally:
+        conn.close()
+    assert results
+    assert results[0][0] == "wiki/photosynthesis.md"
+
+
+def test_semantic_search_returns_empty_when_no_chunks(
+    vault_with_schema: Path, shared_embedder
+):
+    """An initialized but empty index returns no semantic results."""
+    schema_sql = vault_with_schema / ".mcbrain" / "bin" / "schema.sql"
+    ops.init_db(ops.index_db_path(vault_with_schema), schema_sql)
+
+    conn = ops.open_db(vault_with_schema)
+    try:
+        results = ops.semantic_search(conn, "anything")
+    finally:
+        conn.close()
+    assert results == []
+
+
+# ----------------------------- query (hybrid) -------------------------------
+
+
+def _capture_query(vault: Path, text: str, k: int, capsys) -> dict:
+    rc = ops.cmd_query(vault, text, k)
+    assert rc == 0, "cmd_query failed"
+    return json.loads(capsys.readouterr().out)
+
+
+def test_query_hybrid_top1_lexical_winner(populated_vault: Path, capsys):
+    """A query whose words appear in the matching page wins."""
+    payload = _capture_query(populated_vault, "heart attack", 4, capsys)
+    assert payload["mode"] == "lexical+semantic"
+    assert payload["results"][0]["path"] == "wiki/myocardial-infarction.md"
+
+
+def test_query_hybrid_top1_semantic_winner(populated_vault: Path, capsys):
+    """A paraphrase with no lexical overlap relies on the semantic side."""
+    payload = _capture_query(populated_vault, "cardiac event", 4, capsys)
+    assert payload["results"][0]["path"] == "wiki/myocardial-infarction.md"
+
+
+def test_query_hybrid_results_have_excerpts(populated_vault: Path, capsys):
+    payload = _capture_query(populated_vault, "neural network model size", 2, capsys)
+    for r in payload["results"]:
+        assert isinstance(r["excerpt"], str) and r["excerpt"]
+        assert isinstance(r["score"], (int, float))
+        assert r["score"] > 0
+
+
+def test_query_respects_k_parameter(populated_vault: Path, capsys):
+    payload = _capture_query(populated_vault, "bread fermentation", 1, capsys)
+    assert len(payload["results"]) == 1
+
+
+def test_query_empty_text_exits_nonzero(populated_vault: Path):
+    with pytest.raises(SystemExit) as exc:
+        ops.cmd_query(populated_vault, "   ", 4)
+    assert exc.value.code == 2
+
+
+# ----------------------------- no-index fallback ----------------------------
+
+
+def test_query_falls_back_to_lexical_when_no_index(
+    fresh_vault: Path, capsys, monkeypatch
+):
+    """A vault without .mcbrain/index.db should still answer queries via
+    the pure-Python lexical search."""
+    monkeypatch.setattr(ops.shutil, "which", lambda name: None)
+    rc = ops.cmd_query(fresh_vault, "heart attack", 3)
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["mode"] == "lexical"
+    paths = [r["path"] for r in payload["results"]]
+    assert "wiki/myocardial-infarction.md" in paths
+
+
+# --------------------- lazy text fetch (regression) -------------------------
+
+
+def test_query_does_not_load_all_text_into_memory(
+    populated_vault: Path, monkeypatch
+):
+    """Regression for bead McBrain-rtp.
+
+    During cmd_query, no SQL statement may issue `SELECT ... text FROM chunks`
+    without a WHERE clause. Text must only be fetched for the top-K paths.
+
+    Implementation: replace open_db with a wrapper that installs sqlite3's
+    set_trace_callback on each returned connection. The callback receives
+    every SQL statement the connection executes (including via cursors).
+    """
+    seen_sql: list[str] = []
+    real_open_db = ops.open_db
+
+    def open_db_with_trace(vault):
+        conn = real_open_db(vault)
+        conn.set_trace_callback(seen_sql.append)
+        return conn
+
+    monkeypatch.setattr(ops, "open_db", open_db_with_trace)
+
+    ops.cmd_query(populated_vault, "heart attack", 3)
+
+    # No SELECT that pulls `text` without a WHERE filter.
+    offending = [
+        sql
+        for sql in seen_sql
+        if "FROM chunks" in sql
+        and "text" in sql.lower()
+        and "WHERE" not in sql.upper()
+    ]
+    assert offending == [], f"unbounded text SELECTs leaked: {offending}"
+
+    # The lazy SELECT (with WHERE path IN (...)) MUST be issued so we know
+    # the optimization actually ran rather than being silently absent.
+    lazy_selects = [
+        sql
+        for sql in seen_sql
+        if "SELECT path, text FROM chunks WHERE path IN" in sql
+    ]
+    assert lazy_selects, "expected lazy-fetch SELECT to run"

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,66 @@
+"""Static / smoke tests — the floor of the Testing Trophy.
+
+These run without fastembed or numpy and catch the cheapest possible class
+of regression: the module won't import, or argparse is broken.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import mcbrain_ops
+
+
+def test_module_imports():
+    """The script imports without triggering heavy deps."""
+    assert hasattr(mcbrain_ops, "main")
+    assert hasattr(mcbrain_ops, "build_parser")
+
+
+def test_help_lists_all_subcommands(script_dir):
+    """The top-level --help mentions every subcommand."""
+    result = subprocess.run(
+        [sys.executable, str(script_dir / "mcbrain_ops.py"), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    for cmd in ("query", "index", "migrate", "uninstall"):
+        assert cmd in out, f"{cmd} missing from --help"
+
+
+def test_index_subcommands_listed(script_dir):
+    result = subprocess.run(
+        [sys.executable, str(script_dir / "mcbrain_ops.py"), "index", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    for op in ("sync", "rebuild", "status"):
+        assert op in result.stdout, f"{op} missing from index --help"
+
+
+def test_constants_match_schema():
+    """Constants in the script must agree with what's encoded in the schema."""
+    assert mcbrain_ops.EMBEDDING_DIM == 384
+    assert mcbrain_ops.EMBEDDING_MODEL == "BAAI/bge-small-en-v1.5"
+    assert mcbrain_ops.SCHEMA_VERSION == "1"
+
+
+def test_no_unbounded_text_select_in_query(script_dir):
+    """Regression test for the lazy-text-fetch optimization (bead McBrain-rtp).
+
+    The query subcommand must never SELECT chunks.text without a WHERE
+    clause — that's the bug we explicitly fixed. Grep the source.
+    """
+    src = (script_dir / "mcbrain_ops.py").read_text(encoding="utf-8")
+    assert "SELECT path, text FROM chunks WHERE" in src, (
+        "expected the lazy-fetch SELECT (with WHERE) to be present"
+    )
+    # Look for any SELECT that pulls text without a WHERE clause. Naive but
+    # catches the regression we care about.
+    assert "SELECT path, text FROM chunks\"" not in src
+    assert "SELECT path, text FROM chunks " not in src.replace(
+        "SELECT path, text FROM chunks WHERE", ""
+    )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,0 +1,166 @@
+"""Unit tests — pure-Python logic, no DB, no embedder.
+
+These run without fastembed or numpy and exercise small focused pieces:
+RRF math, excerpt rendering, hashing, path manipulation, blob round-trip
+(the blob round-trip lazily imports numpy via the helper, so it does need
+numpy in the test runner).
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+import mcbrain_ops as ops
+
+
+# ----------------------------- rrf_fuse -------------------------------------
+
+
+def test_rrf_fuse_single_list_descending_by_rank():
+    """Reciprocal rank fusion over one list = 1/(k+rank+1)."""
+    fused = ops.rrf_fuse([["a", "b", "c"]], k=60)
+    assert fused["a"] == pytest.approx(1 / 61)
+    assert fused["b"] == pytest.approx(1 / 62)
+    assert fused["c"] == pytest.approx(1 / 63)
+    assert fused["a"] > fused["b"] > fused["c"]
+
+
+def test_rrf_fuse_two_lists_overlap_boosts_score():
+    """A doc that appears in both lists scores higher than one that's only in one."""
+    fused = ops.rrf_fuse([["a", "b"], ["a", "c"]], k=60)
+    assert fused["a"] == pytest.approx(2 / 61)
+    assert fused["b"] == pytest.approx(1 / 62)
+    assert fused["c"] == pytest.approx(1 / 62)
+    assert fused["a"] > fused["b"]
+    assert fused["a"] > fused["c"]
+
+
+def test_rrf_fuse_disjoint_lists_no_overlap():
+    fused = ops.rrf_fuse([["a"], ["b"]], k=60)
+    assert fused["a"] == pytest.approx(1 / 61)
+    assert fused["b"] == pytest.approx(1 / 61)
+
+
+def test_rrf_fuse_empty():
+    assert ops.rrf_fuse([]) == {}
+    assert ops.rrf_fuse([[]]) == {}
+
+
+def test_rrf_fuse_default_k_is_60():
+    """Module constant should match what the function uses by default."""
+    assert ops.RRF_K == 60
+    fused = ops.rrf_fuse([["x"]])
+    assert fused["x"] == pytest.approx(1 / 61)
+
+
+# ----------------------------- make_excerpt --------------------------------
+
+
+def test_make_excerpt_picks_first_body_line():
+    text = (
+        "---\n"
+        "type: concept\n"
+        "---\n"
+        "\n"
+        "# Heading\n"
+        "\n"
+        "This is the first body sentence.\n"
+        "Second line that won't be used.\n"
+    )
+    assert ops.make_excerpt(text) == "This is the first body sentence."
+
+
+def test_make_excerpt_truncates_long_lines():
+    long_line = "A" * 500
+    excerpt = ops.make_excerpt(long_line, max_chars=240)
+    assert len(excerpt) <= 241  # 240 chars + the ellipsis
+    assert excerpt.endswith("…")
+
+
+def test_make_excerpt_falls_back_when_only_headings():
+    """If every line is empty / frontmatter / heading, fall back to the whole text."""
+    text = "---\n---\n# Heading\n## Sub\n"
+    excerpt = ops.make_excerpt(text)
+    assert excerpt  # nonempty
+    assert "Heading" in excerpt or "Sub" in excerpt
+
+
+def test_make_excerpt_empty_text():
+    assert ops.make_excerpt("") == ""
+
+
+# ----------------------------- hashing -------------------------------------
+
+
+def test_hash_file_deterministic(tmp_path: Path):
+    p = tmp_path / "x.md"
+    p.write_text("hello world", encoding="utf-8")
+    h1 = ops.hash_file(p)
+    h2 = ops.hash_file(p)
+    assert h1 == h2
+    assert len(h1) == 64  # SHA-256 hex
+
+
+def test_hash_file_changes_with_content(tmp_path: Path):
+    p = tmp_path / "x.md"
+    p.write_text("v1", encoding="utf-8")
+    h1 = ops.hash_file(p)
+    p.write_text("v2", encoding="utf-8")
+    h2 = ops.hash_file(p)
+    assert h1 != h2
+
+
+# ----------------------------- path helpers --------------------------------
+
+
+def test_relative_wiki_path_is_posix(tmp_path: Path):
+    """Even on Windows, the stored key uses forward slashes."""
+    vault = tmp_path / "v"
+    page = vault / "wiki" / "sub" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("x")
+    rel = ops.relative_wiki_path(vault, page)
+    assert rel == "wiki/sub/page.md"
+
+
+def test_venv_python_picks_correct_path_per_platform(monkeypatch, tmp_path: Path):
+    """POSIX → bin/python; Windows → Scripts/python.exe."""
+    vault = tmp_path / "v"
+    monkeypatch.setattr(ops, "is_windows", lambda: False)
+    posix = ops.venv_python(vault)
+    assert posix.parts[-2:] == ("bin", "python")
+
+    monkeypatch.setattr(ops, "is_windows", lambda: True)
+    win = ops.venv_python(vault)
+    assert win.parts[-2:] == ("Scripts", "python.exe")
+
+
+# ----------------------------- blob round-trip ------------------------------
+
+
+def test_embedding_blob_round_trip():
+    """numpy array → blob → numpy array preserves bytes exactly."""
+    pytest.importorskip("numpy")
+    import numpy as np
+
+    arr = np.arange(384, dtype=np.float32)
+    blob = ops.embedding_to_blob(arr)
+    assert isinstance(blob, (bytes, bytearray))
+    assert len(blob) == 384 * 4
+
+    restored = ops.blob_to_embedding(blob)
+    assert restored.dtype == np.float32
+    assert restored.shape == (384,)
+    np.testing.assert_array_equal(arr, restored)
+
+
+def test_embedding_blob_handles_python_list():
+    """embedding_to_blob accepts a list (i.e., not pre-shaped as float32)."""
+    pytest.importorskip("numpy")
+    import numpy as np
+
+    blob = ops.embedding_to_blob([1.0, 2.0, 3.0])
+    arr = ops.blob_to_embedding(blob)
+    assert arr.tolist() == [1.0, 2.0, 3.0]


### PR DESCRIPTION
Closes #2.

## Summary

Every McBrain vault gets a built-in hybrid lexical + semantic search index that's provisioned automatically at setup time, kept in sync after every wiki edit, and queried on every "ask my brain" request — no user setup required, no system-wide installs.

- **Lexical:** ripgrep (`rg`) when available, with a `grep` / pure-Python fallback so the lexical path always works
- **Semantic:** [FastEmbed](https://github.com/qdrant/fastembed) `BAAI/bge-small-en-v1.5` (CPU-only ONNX, 384 dims, ~30 MB shared cache)
- **Hybrid ranking:** Reciprocal Rank Fusion (k=60)
- **Storage:** per-vault SQLite at `<vault>/.mcbrain/index.db`; brute-force cosine in numpy
- **Cross-platform:** macOS, Linux, Windows
- **Self-contained:** all per-vault state under `<vault>/.mcbrain/`; no system package-manager invocations

## What's in this PR

- New `mcbrain-ops` skill — the only place Python lives in McBrain. Six subcommands: `query`, `index sync`, `index rebuild`, `index status`, `migrate`, `uninstall`. ~700 LoC dispatcher.
- `mcbrain-setup` Step 5.5 (cross-platform prereq detection, no installs) and Step 8.5 (auto-provisioning via `mcbrain-ops migrate`).
- `claude-md-template.md` rewritten so fresh vaults' Query operation delegates to `mcbrain-ops`; ingest procedures gain an `index sync` step.
- `mcbrain` skill gained Step 2.5 — Migration check that detects pre-engine vaults and offers an automatic upgrade.
- Per-vault `.gitignore` updated to exclude the venv and index but track the script.
- Lazy text fetch optimization (McBrain-rtp): query subcommand only loads text for top-K paths, not the entire chunks table.
- Pytest suite under `tests/` — 66 tests across six files following the [Testing Trophy](https://kentcdodds.com/blog/the-testing-trophy-and-testing-classifications). Full suite runs in ~3.5s after the model is cached.

## One plan deviation

The locked plan said FastEmbed + sqlite-vec. sqlite-vec needs `enable_load_extension` which is missing from many Python builds (notably pyenv on macOS). The plan's risks section already authorized a numpy brute-force fallback if a platform failed; I made that the primary path. Result: cross-platform without forcing users onto a specific Python build. At personal-wiki scale (low thousands of pages) brute-force cosine is sub-10 ms.

## Verification

- 66 pytest tests pass: static / unit / patcher / DB integration / search behavior / E2E lifecycle through the CLI
- Manual smoke: `migrate → query → sync (with new file) → query` against a 5-page scratch vault. Pure-semantic queries with zero lexical overlap (`cardiac event`, `bread fermentation`, `how plants make food`, `spooky action at a distance`) all return the correct top-1.
- CLAUDE.md patcher idempotency confirmed: re-running migrate on a fully migrated vault is a no-op.
- Existing vaults migrate in place via the Step 2.5 prompt.

## Test plan for the reviewer

- [ ] Install this branch as a Claude plugin marketplace
- [ ] Run `mcbrain-setup` against a brand-new vault and confirm `<vault>/.mcbrain/{venv,bin,index.db}` are created
- [ ] Confirm `python3` and `rg` detection surfaces install instructions when missing (without invoking `brew`/`winget`/`apt`)
- [ ] Ingest a couple of sources and confirm `index sync` runs after each
- [ ] Query the vault with both keyword and paraphrased phrasings; confirm relevant pages come back
- [ ] On a vault that pre-dates this change, confirm the `mcbrain` skill offers a migration prompt
- [ ] Optional: run the test suite — instructions in `tests/README.md`

## Companion issue

[#3 "Consider QMD as the McBrain search engine"](https://github.com/jbdamask/McBrain/issues/3) captures qmd as a future option to revisit if the constraints around footprint, vault-local state, or Windows support change upstream.