### PR TITLE
Server-side Notion ingest tool on mcbrain-engine MCP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "mcbrain",
       "source": "./plugins/mcbrain",
       "description": "Build and operate McBrain — a personal LLM-maintained knowledge base in Obsidian — backed by a local mcbrain-engine MCP server (installed once per machine) so search works in both Claude Code and Claude Cowork. Includes companion skills for spinning up Notion research trackers and executing queued research tasks back into the wiki.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": {
         "name": "John Damask",
         "email": "jbdamask@gmail.com"

--- a/plugins/mcbrain/.claude-plugin/plugin.json
+++ b/plugins/mcbrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcbrain",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Build and operate McBrain — a persistent, LLM-maintained personal knowledge base based on Karpathy's LLM Wiki pattern. Hybrid lexical+semantic search runs through a shared local mcbrain-engine MCP server installed once per machine, so McBrain works in both Claude Code and Claude Cowork (Desktop). Bundles four cooperating skills: one-shot vault setup, day-to-day operations (ingest/query/lint/synth), Notion research-tracker creation, and a queue runner that drains research tasks and writes findings back to Notion.",
   "author": {
     "name": "John Damask"

--- a/plugins/mcbrain/mcp-server/mcbrain_engine.py
+++ b/plugins/mcbrain/mcp-server/mcbrain_engine.py
@@ -1006,6 +1006,156 @@ def read_registry_safe() -> dict:
         return {}
 
 
+# ----------------------------- Notion ingest --------------------------------
+
+
+def _vault_notion_config(name: str) -> dict:
+    """Return the Notion config for a vault. Raises EngineError if not enabled."""
+    import registry
+
+    entry = registry.find_vault_by_name(name)
+    if not entry:
+        raise EngineError(f"vault {name!r} is not registered")
+    if not entry.get("notion_enabled"):
+        raise EngineError(
+            f"Vault {name!r} is not configured for Notion ingest. "
+            "Run mcbrain-setup Step 8 to enable it, or call "
+            "enable_notion_for_vault(vault, database_id) first."
+        )
+    db_id = entry.get("notion_db_id")
+    if not db_id:
+        raise EngineError(
+            f"Vault {name!r} is marked notion_enabled but has no "
+            "notion_db_id — registry corruption. Re-run setup Step 8."
+        )
+    return {"db_id": db_id, "vault_path": Path(entry["path"])}
+
+
+def enable_notion_for_vault_impl(vault: Path, name: str, db_id: str) -> dict:
+    """Mark a registered vault as Notion-enabled with the given database id."""
+    import registry
+
+    if name == UNREGISTERED:
+        raise EngineError(
+            f"vault at {vault} is not registered — call migrate first"
+        )
+    try:
+        registry.set_notion_config(name, db_id)
+    except (KeyError, ValueError) as e:
+        raise EngineError(str(e)) from e
+    return {
+        "vault_name": name,
+        "vault_path": str(vault),
+        "notion_enabled": True,
+        "notion_db_id": registry.find_vault_by_name(name)["notion_db_id"],
+    }
+
+
+def disable_notion_for_vault_impl(vault: Path, name: str) -> dict:
+    import registry
+
+    if name == UNREGISTERED:
+        raise EngineError(
+            f"vault at {vault} is not registered — nothing to disable"
+        )
+    try:
+        registry.set_notion_config(name, None)
+    except KeyError as e:
+        raise EngineError(str(e)) from e
+    return {"vault_name": name, "vault_path": str(vault), "notion_enabled": False}
+
+
+def ingest_from_notion_impl(
+    vault: Path,
+    name: str,
+    database_id: str | None = None,
+    page_ids: list[str] | None = None,
+    filter_: dict | None = None,
+) -> dict:
+    """Server-side Notion → vault/raw/notes ingest.
+
+    Refuses if the vault hasn't been Notion-enabled. Drains the configured
+    database (or the explicit `database_id` override / explicit `page_ids`),
+    converts each page's blocks to markdown, and writes them under
+    `<vault>/raw/notes/`. Idempotent: pages whose `last_edited_time` is older
+    than the local file's frontmatter are skipped.
+
+    Returns: {imported_files, imported_count, skipped_count, errors}
+    """
+    import notion
+
+    cfg = _vault_notion_config(name)
+    db_to_drain = database_id or cfg["db_id"]
+
+    raw_notes = vault / "raw" / "notes"
+    raw_notes.mkdir(parents=True, exist_ok=True)
+
+    # Resolve the page set: explicit page_ids > database query.
+    if page_ids:
+        pages = [notion.get_page(pid) for pid in page_ids]
+    else:
+        pages = notion.query_database(db_to_drain, filter_)
+
+    imported: list[str] = []
+    skipped: list[str] = []
+    errors: list[dict] = []
+
+    for page in pages:
+        page_id = page.get("id", "<unknown>")
+        last_edited = page.get("last_edited_time", "")
+        try:
+            # Idempotency: peek at any existing file with this notion_id by
+            # scanning the dir's frontmatter. Cheap because raw/notes/ is small.
+            existing = _find_local_by_notion_id(raw_notes, page_id)
+            if existing is not None:
+                fm = notion.read_frontmatter(existing)
+                if fm.get("last_edited_time") == last_edited and last_edited:
+                    skipped.append(existing.name)
+                    continue
+
+            blocks = notion.get_blocks(page_id)
+            filename, body = notion.page_to_markdown(page, blocks)
+
+            # If we found an existing file but the title changed (different
+            # slug), keep the old filename so cross-references stay stable.
+            if existing is not None and existing.name != filename:
+                filename = existing.name
+
+            target = raw_notes / filename
+            target.write_text(body, encoding="utf-8")
+            imported.append(filename)
+        except notion.NotionError as e:
+            errors.append({"page_id": page_id, "error": str(e)})
+        except Exception as e:  # noqa: BLE001 — surface anything else with context
+            errors.append(
+                {"page_id": page_id, "error": f"{type(e).__name__}: {e}"}
+            )
+
+    return {
+        "vault_name": name,
+        "vault_path": str(vault),
+        "database_id": db_to_drain,
+        "imported_count": len(imported),
+        "imported_files": imported,
+        "skipped_count": len(skipped),
+        "skipped_files": skipped,
+        "errors": errors,
+    }
+
+
+def _find_local_by_notion_id(raw_notes: Path, notion_id: str) -> Path | None:
+    """Scan raw/notes/ for a markdown file whose frontmatter matches notion_id."""
+    import notion
+
+    if not raw_notes.is_dir():
+        return None
+    for md in raw_notes.glob("*.md"):
+        fm = notion.read_frontmatter(md)
+        if fm.get("notion_id") == notion_id:
+            return md
+    return None
+
+
 # ---------------------------- MCP wire layer --------------------------------
 
 
@@ -1064,6 +1214,52 @@ if FastMCP is not None:
         """Return every registered vault and its provisioned status."""
         return list_vaults_impl()
 
+    @mcp.tool()
+    def enable_notion_for_vault(vault: str, database_id: str) -> dict:
+        """Enable Notion ingest for a vault, with the database to drain.
+
+        Records `notion_enabled=True` and the canonicalized `notion_db_id`
+        in the vault registry. The vault must already be registered (call
+        `migrate` first). Idempotent — re-running with the same id is a no-op.
+        """
+        name, path = resolve_vault(vault)
+        require_registered(name, path)
+        return enable_notion_for_vault_impl(path, name, database_id)
+
+    @mcp.tool()
+    def disable_notion_for_vault(vault: str) -> dict:
+        """Clear a vault's Notion configuration. The integration token and
+        the local raw/notes/ files are left in place; only the registry flag
+        is reset."""
+        name, path = resolve_vault(vault)
+        require_registered(name, path)
+        return disable_notion_for_vault_impl(path, name)
+
+    @mcp.tool()
+    def ingest_from_notion(
+        vault: str,
+        database_id: str | None = None,
+        page_ids: list[str] | None = None,
+        filter: dict | None = None,
+    ) -> dict:
+        """Server-side ingest from a Notion database into <vault>/raw/notes/.
+
+        Refuses if the vault hasn't been Notion-enabled (run
+        `enable_notion_for_vault` first, or do it via mcbrain-setup Step 8).
+        The page bodies are written directly to disk — they do NOT pass
+        through the LLM context. Returns only summary counts + filenames.
+
+        Idempotent: pages whose `last_edited_time` matches the local
+        frontmatter are skipped. If `database_id` is omitted, the vault's
+        registered Notion DB is used. If `page_ids` is given, only those
+        pages are fetched; otherwise the database is drained.
+        """
+        name, path = resolve_vault(vault)
+        require_registered(name, path)
+        return ingest_from_notion_impl(
+            path, name, database_id=database_id, page_ids=page_ids, filter_=filter
+        )
+
 
 TOOL_NAMES = (
     "query",
@@ -1073,6 +1269,9 @@ TOOL_NAMES = (
     "migrate",
     "uninstall",
     "list_vaults",
+    "enable_notion_for_vault",
+    "disable_notion_for_vault",
+    "ingest_from_notion",
 )
 
 

--- a/plugins/mcbrain/mcp-server/notion.py
+++ b/plugins/mcbrain/mcp-server/notion.py
@@ -1,0 +1,403 @@
+"""Notion REST client + block-to-markdown converter for server-side ingest.
+
+Stdlib-only (urllib + json + re) so we don't pull `requests` into the engine
+runtime. Notion's API is JSON over HTTPS; this is sufficient.
+
+Public entry points:
+- read_token() -> str
+- query_database(db_id) -> list[page]
+- get_page(page_id) -> page
+- get_blocks(block_id) -> list[block]   # recursive children resolved
+- page_to_markdown(page, blocks) -> (filename, body)
+
+API version pinned to 2022-06-28 (Notion's stable release).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import paths
+
+NOTION_API_BASE = "https://api.notion.com/v1"
+NOTION_API_VERSION = "2022-06-28"
+HTTP_TIMEOUT_SECONDS = 30
+MAX_RETRIES = 3
+PAGE_SIZE = 100  # Notion's max for paginated endpoints
+
+
+class NotionError(Exception):
+    """Raised on token/auth/network/API failures the user should see."""
+
+
+# ----------------------------- token I/O ------------------------------------
+
+
+def read_token() -> str:
+    """Read the Notion integration token. Raises NotionError if missing."""
+    path = paths.notion_token_path()
+    if not path.is_file():
+        raise NotionError(
+            f"Notion integration token not found at {path}. "
+            "Run mcbrain-setup Step 8f to configure, or write the token "
+            "manually (single line, no whitespace)."
+        )
+    token = path.read_text(encoding="utf-8").strip()
+    if not token:
+        raise NotionError(f"Notion token file at {path} is empty.")
+    return token
+
+
+# ----------------------------- HTTP -----------------------------------------
+
+
+def _request(method: str, path_: str, body: dict | None = None) -> dict:
+    url = NOTION_API_BASE + path_
+    headers = {
+        "Authorization": f"Bearer {read_token()}",
+        "Notion-Version": NOTION_API_VERSION,
+        "Content-Type": "application/json",
+    }
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+
+    last_err: Exception | None = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+                payload = resp.read()
+                return json.loads(payload.decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            err_body = e.read().decode("utf-8", errors="replace")
+            # Retry on rate-limit (429) and 5xx; surface 4xx immediately.
+            if e.code == 429 or 500 <= e.code < 600:
+                last_err = NotionError(
+                    f"Notion API {e.code} on {method} {path_}: {err_body[:200]}"
+                )
+                if attempt < MAX_RETRIES:
+                    time.sleep(2 ** attempt)
+                    continue
+                raise last_err from e
+            raise NotionError(
+                f"Notion API {e.code} on {method} {path_}: {err_body[:500]}"
+            ) from e
+        except urllib.error.URLError as e:
+            last_err = NotionError(f"Notion network error on {method} {path_}: {e}")
+            if attempt < MAX_RETRIES:
+                time.sleep(2 ** attempt)
+                continue
+            raise last_err
+    # Unreachable, but mypy/pyright happy:
+    raise last_err or NotionError("unknown Notion API failure")
+
+
+def _paginate(method: str, path_: str, body: dict | None = None) -> list[dict]:
+    """Drain a paginated endpoint. Body is reused across pages with start_cursor."""
+    results: list[dict] = []
+    cursor: str | None = None
+    while True:
+        page_body = dict(body or {})
+        page_body["page_size"] = PAGE_SIZE
+        if cursor:
+            page_body["start_cursor"] = cursor
+        resp = _request(method, path_, page_body if method != "GET" else None)
+        # GET endpoints (e.g. blocks/{id}/children) take query params instead.
+        if method == "GET" and (cursor or "page_size" in (body or {})):
+            qs = urllib.parse.urlencode(
+                {k: v for k, v in page_body.items() if k in ("page_size", "start_cursor")}
+            )
+            sep = "&" if "?" in path_ else "?"
+            resp = _request("GET", f"{path_}{sep}{qs}", None)
+        results.extend(resp.get("results", []))
+        if not resp.get("has_more"):
+            break
+        cursor = resp.get("next_cursor")
+        if not cursor:
+            break
+    return results
+
+
+# ----------------------------- API surface ----------------------------------
+
+
+def query_database(db_id: str, filter_: dict | None = None) -> list[dict]:
+    """Return every page in a database (paginated drain)."""
+    body: dict = {}
+    if filter_:
+        body["filter"] = filter_
+    return _paginate("POST", f"/databases/{db_id}/query", body)
+
+
+def get_page(page_id: str) -> dict:
+    """Fetch a single page's properties + metadata (no body content)."""
+    return _request("GET", f"/pages/{page_id}")
+
+
+def get_blocks(block_id: str) -> list[dict]:
+    """Recursively fetch all child blocks of `block_id`.
+
+    For each block with `has_children=True`, recursively fetches its children
+    and attaches them under the synthetic `_children` key (Notion's API does
+    not include children inline; we compose them ourselves).
+    """
+    children = _paginate("GET", f"/blocks/{block_id}/children")
+    for block in children:
+        if block.get("has_children"):
+            block["_children"] = get_blocks(block["id"])
+    return children
+
+
+# ----------------------------- markdown conversion --------------------------
+
+
+def _rich_text_to_md(rich: list[dict]) -> str:
+    """Convert Notion rich_text array to inline markdown."""
+    out: list[str] = []
+    for span in rich:
+        text = span.get("plain_text", "")
+        if not text:
+            continue
+        ann = span.get("annotations", {})
+        if ann.get("code"):
+            text = f"`{text}`"
+        if ann.get("bold"):
+            text = f"**{text}**"
+        if ann.get("italic"):
+            text = f"*{text}*"
+        if ann.get("strikethrough"):
+            text = f"~~{text}~~"
+        href = span.get("href")
+        if href:
+            text = f"[{text}]({href})"
+        out.append(text)
+    return "".join(out)
+
+
+def _block_to_md(block: dict, list_index: int = 1, depth: int = 0) -> str:
+    """Convert a single block (and its `_children`) to markdown.
+
+    `list_index` is used for numbered_list_item. `depth` controls indentation
+    for nested lists.
+    """
+    btype = block.get("type", "")
+    indent = "  " * depth
+    children = block.get("_children", [])
+
+    if btype == "paragraph":
+        text = _rich_text_to_md(block["paragraph"]["rich_text"])
+        out = f"{indent}{text}" if text else ""
+        if children:
+            out += "\n" + _children_to_md(children, depth + 1)
+        return out
+
+    if btype.startswith("heading_"):
+        level = int(btype.split("_")[1])
+        text = _rich_text_to_md(block[btype]["rich_text"])
+        return f"{'#' * level} {text}"
+
+    if btype == "bulleted_list_item":
+        text = _rich_text_to_md(block["bulleted_list_item"]["rich_text"])
+        out = f"{indent}- {text}"
+        if children:
+            out += "\n" + _children_to_md(children, depth + 1)
+        return out
+
+    if btype == "numbered_list_item":
+        text = _rich_text_to_md(block["numbered_list_item"]["rich_text"])
+        out = f"{indent}{list_index}. {text}"
+        if children:
+            out += "\n" + _children_to_md(children, depth + 1)
+        return out
+
+    if btype == "to_do":
+        text = _rich_text_to_md(block["to_do"]["rich_text"])
+        checked = "x" if block["to_do"].get("checked") else " "
+        return f"{indent}- [{checked}] {text}"
+
+    if btype == "toggle":
+        text = _rich_text_to_md(block["toggle"]["rich_text"])
+        out = f"{indent}- {text}"
+        if children:
+            out += "\n" + _children_to_md(children, depth + 1)
+        return out
+
+    if btype == "code":
+        lang = block["code"].get("language", "")
+        text = _rich_text_to_md(block["code"]["rich_text"])
+        # Code blocks shouldn't carry inline markdown — strip backticks added
+        # by _rich_text_to_md for code annotation.
+        text_plain = "".join(s.get("plain_text", "") for s in block["code"]["rich_text"])
+        return f"```{lang}\n{text_plain}\n```"
+
+    if btype == "quote":
+        text = _rich_text_to_md(block["quote"]["rich_text"])
+        # Multi-line quotes get `>` per line.
+        return "\n".join(f"> {line}" for line in text.split("\n"))
+
+    if btype == "callout":
+        emoji = ""
+        icon = block["callout"].get("icon")
+        if icon and icon.get("type") == "emoji":
+            emoji = icon["emoji"] + " "
+        text = _rich_text_to_md(block["callout"]["rich_text"])
+        return f"> {emoji}{text}"
+
+    if btype == "divider":
+        return "---"
+
+    if btype == "image":
+        img = block["image"]
+        url = img.get("file", {}).get("url") or img.get("external", {}).get("url", "")
+        caption = _rich_text_to_md(img.get("caption", []))
+        return f"![{caption}]({url})"
+
+    if btype == "equation":
+        expr = block["equation"].get("expression", "")
+        return f"$$\n{expr}\n$$"
+
+    if btype == "bookmark":
+        url = block["bookmark"].get("url", "")
+        caption = _rich_text_to_md(block["bookmark"].get("caption", []))
+        return f"[{caption or url}]({url})"
+
+    if btype == "child_page":
+        title = block["child_page"].get("title", "Untitled")
+        return f"<!-- child_page: {title} (id={block['id']}) -->"
+
+    if btype == "table":
+        # Tables have rows as children; each row is a `table_row` block.
+        if not children:
+            return f"<!-- empty table id={block['id']} -->"
+        rows = []
+        for row in children:
+            cells = row["table_row"].get("cells", [])
+            row_md = " | ".join(_rich_text_to_md(c) or "" for c in cells)
+            rows.append(f"| {row_md} |")
+        if rows:
+            # Insert a header separator after row 0.
+            sep = "| " + " | ".join("---" for _ in cells) + " |"
+            rows.insert(1, sep)
+        return "\n".join(rows)
+
+    # Unhandled types — preserve as a comment so the user knows something existed.
+    return f"<!-- unsupported notion block type: {btype} -->"
+
+
+_LIST_BLOCK_TYPES = {"bulleted_list_item", "numbered_list_item", "to_do"}
+
+
+def _children_to_md(blocks: list[dict], depth: int = 0) -> str:
+    """Convert a sequence of sibling blocks to markdown.
+
+    Tracks numbered_list_item runs so consecutive items get sequential indices.
+    Joins adjacent list items with single newlines (tight lists); other block
+    transitions get blank-line separation.
+    """
+    parts: list[tuple[str, str]] = []  # (block_type, rendered)
+    n_index = 1
+    prev_type: str | None = None
+    for block in blocks:
+        btype = block.get("type", "")
+        if btype == "numbered_list_item":
+            if prev_type != "numbered_list_item":
+                n_index = 1
+            rendered = _block_to_md(block, list_index=n_index, depth=depth)
+            n_index += 1
+        else:
+            rendered = _block_to_md(block, depth=depth)
+        if rendered:
+            parts.append((btype, rendered))
+        prev_type = btype
+
+    out: list[str] = []
+    for i, (btype, rendered) in enumerate(parts):
+        out.append(rendered)
+        if i + 1 < len(parts):
+            next_type = parts[i + 1][0]
+            # Tight join only when both blocks are the same list type (bullets
+            # next to bullets, numbered next to numbered, todo next to todo).
+            if btype in _LIST_BLOCK_TYPES and btype == next_type:
+                out.append("\n")
+            else:
+                out.append("\n\n")
+    return "".join(out)
+
+
+# ----------------------------- page assembly --------------------------------
+
+
+_SLUG_NONALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(title: str, fallback: str) -> str:
+    s = _SLUG_NONALNUM.sub("-", title.lower()).strip("-")
+    return s or fallback
+
+
+def _page_title(page: dict) -> str:
+    """Extract the page's title from its properties (whichever prop is type=title)."""
+    props = page.get("properties", {})
+    for prop in props.values():
+        if prop.get("type") == "title":
+            return _rich_text_to_md(prop["title"]) or "Untitled"
+    return "Untitled"
+
+
+def page_to_markdown(page: dict, blocks: list[dict]) -> tuple[str, str]:
+    """Render a Notion page + its blocks as (filename, body).
+
+    Filename: <slugified-title>-<short-id>.md (short-id from page['id'] for
+    collision safety).
+    Body: YAML frontmatter (notion_id/url/edited/imported) + `# Title` + blocks.
+    """
+    title = _page_title(page)
+    short_id = page["id"].replace("-", "")[:8]
+    filename = f"{_slugify(title, short_id)}-{short_id}.md"
+
+    fm_lines = [
+        "---",
+        f"notion_id: {page['id']}",
+        f"notion_url: {page.get('url', '')}",
+        f"last_edited_time: {page.get('last_edited_time', '')}",
+        f"imported_at: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}",
+        "---",
+    ]
+    body = "\n".join(fm_lines) + f"\n\n# {title}\n\n" + _children_to_md(blocks)
+    return filename, body.rstrip() + "\n"
+
+
+# ----------------------------- frontmatter helpers --------------------------
+
+
+_FM_LINE_RE = re.compile(r"^([a-z_]+):\s*(.*)$")
+
+
+def read_frontmatter(md_path: Path) -> dict[str, str]:
+    """Best-effort YAML frontmatter parser for our own generated files.
+
+    Only supports the flat key:value form we write. Returns empty dict if
+    the file has no frontmatter or doesn't exist.
+    """
+    if not md_path.is_file():
+        return {}
+    text = md_path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return {}
+    try:
+        end = text.index("\n---\n", 4)
+    except ValueError:
+        return {}
+    out: dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        m = _FM_LINE_RE.match(line)
+        if m:
+            out[m.group(1)] = m.group(2).strip()
+    return out

--- a/plugins/mcbrain/mcp-server/paths.py
+++ b/plugins/mcbrain/mcp-server/paths.py
@@ -87,3 +87,8 @@ def claude_desktop_config_path() -> Path:
 def claude_code_config_dir() -> Path:
     """Claude Code user-scope config dir — ~/.claude on every OS."""
     return Path.home() / ".claude"
+
+
+def notion_token_path() -> Path:
+    """Notion integration token — sibling of vaults.json under user config."""
+    return registry_path().parent / "notion-token"

--- a/plugins/mcbrain/mcp-server/registry.py
+++ b/plugins/mcbrain/mcp-server/registry.py
@@ -1,7 +1,21 @@
 """Vault registry I/O — atomic-rename writes to platform-resolved vaults.json.
 
 Schema:
-    {"version": 1, "vaults": {"<name>": {"path": "<abs>", "registered": "<UTC ISO>"}}}
+    {
+      "version": 1,
+      "vaults": {
+        "<name>": {
+          "path": "<abs>",
+          "registered": "<UTC ISO>",
+          "notion_enabled": true,           # optional, present if vault opts in
+          "notion_db_id": "<32-char hex>",  # optional, paired with notion_enabled
+        }
+      }
+    }
+
+Older entries without the notion_* keys are valid — read_registry() does not
+require them. The Notion ingest tool checks for `notion_enabled is True`
+before doing any work.
 """
 
 from __future__ import annotations
@@ -55,14 +69,54 @@ def write_registry(data: dict) -> None:
 
 
 def put_vault(name: str, vault_path: Path) -> dict:
-    """Insert or update a vault entry idempotently. Returns the resulting registry."""
+    """Insert or update a vault entry idempotently. Preserves any existing
+    Notion config on the entry. Returns the resulting registry."""
     data = read_registry()
-    data["vaults"][name] = {
+    existing = data["vaults"].get(name, {})
+    entry = {
         "path": str(Path(vault_path).expanduser().resolve()),
         "registered": _iso_now(),
     }
+    # Carry over Notion config if previously set — re-registration must not
+    # silently un-enable Notion ingest for a vault.
+    for key in ("notion_enabled", "notion_db_id"):
+        if key in existing:
+            entry[key] = existing[key]
+    data["vaults"][name] = entry
     write_registry(data)
     return data
+
+
+def set_notion_config(name: str, db_id: str | None) -> dict:
+    """Enable or disable Notion ingest on the named vault.
+
+    Pass `db_id=None` to clear (sets notion_enabled=False, drops notion_db_id).
+    Pass a 32-char hex (with or without dashes) to enable.
+    Raises KeyError if the vault is not registered.
+    """
+    data = read_registry()
+    if name not in data["vaults"]:
+        raise KeyError(f"vault {name!r} is not registered")
+    entry = data["vaults"][name]
+    if db_id is None:
+        entry["notion_enabled"] = False
+        entry.pop("notion_db_id", None)
+    else:
+        entry["notion_enabled"] = True
+        entry["notion_db_id"] = _normalize_db_id(db_id)
+    write_registry(data)
+    return data
+
+
+def _normalize_db_id(db_id: str) -> str:
+    """Normalize a Notion DB ID to dashed canonical form (32 hex with 4 dashes)."""
+    raw = db_id.strip().replace("-", "").lower()
+    if len(raw) != 32 or any(c not in "0123456789abcdef" for c in raw):
+        raise ValueError(
+            f"invalid Notion database id {db_id!r}: expected 32 hex chars "
+            "(with or without dashes)"
+        )
+    return f"{raw[0:8]}-{raw[8:12]}-{raw[12:16]}-{raw[16:20]}-{raw[20:32]}"
 
 
 def remove_vault(name: str) -> bool:

--- a/plugins/mcbrain/skills/mcbrain-ops/SKILL.md
+++ b/plugins/mcbrain/skills/mcbrain-ops/SKILL.md
@@ -37,10 +37,10 @@ Pass the canonical name (or the absolute path as fallback) to the tool.
 
 ## Tool calls
 
-The `mcbrain-engine` MCP exposes five maintenance tools handled here. The
-sixth tool, `query`, is called from the `mcbrain` skill via CLAUDE.md — **not
-from this skill** — because it's part of the user's question-answering flow,
-not maintenance.
+The `mcbrain-engine` MCP exposes eight maintenance tools handled here. The
+ninth tool, `query`, is called from the `mcbrain` skill via CLAUDE.md —
+**not from this skill** — because it's part of the user's question-answering
+flow, not maintenance.
 
 ### `index_sync(vault)`
 
@@ -87,6 +87,61 @@ Removes `<vault>/.mcbrain/` (the per-vault index) and the vault's registry
 entry. Dry-run unless `force=true`. Never touches `wiki/` or `raw/`. The
 shared FastEmbed cache (managed by FastEmbed itself) is intentionally left
 in place so other vaults don't redownload the model.
+
+### `enable_notion_for_vault(vault, database_id)`
+
+Marks a registered vault as Notion-enabled and records the database id to
+drain. Required before `ingest_from_notion` will run against the vault.
+Idempotent — re-running with the same id is a no-op. Vault must already
+be registered (`migrate` first). Returns `{vault_name, vault_path,
+notion_enabled, notion_db_id}`.
+
+The token itself is *not* set by this tool — it lives in a per-machine
+file at `~/Library/Application Support/mcbrain/notion-token` (macOS) or
+`%APPDATA%\mcbrain\notion-token` (Windows). `mcbrain-setup` Step 8f
+captures it on first run; subsequent vaults reuse it.
+
+### `disable_notion_for_vault(vault)`
+
+Clears the registry's Notion config on a vault. The integration token
+file and any already-imported markdown under `<vault>/raw/notes/` are
+left in place — only the registry flag is reset. Use when the user
+stops wanting Notion ingest for a specific vault but keeps it for others.
+
+### `ingest_from_notion(vault, database_id?, page_ids?, filter?)`
+
+**This is the high-leverage tool.** Calls the Notion REST API directly
+from the user's host (not via Claude's Notion connector), converts each
+page's blocks to markdown, and writes the files to `<vault>/raw/notes/`.
+**Page bodies do not pass through the LLM context** — only summary
+counts come back. That's a major token-cost and latency win for bulk
+ingest of 10+ pages.
+
+Refuses to run if the vault isn't Notion-enabled (call
+`enable_notion_for_vault` first). Refuses if the integration token file
+is missing.
+
+Arguments:
+- `vault` — registry name or absolute path (required)
+- `database_id` — optional override; default uses the vault's registered
+  `notion_db_id`
+- `page_ids` — optional list of specific page IDs; if omitted, drains
+  the database
+- `filter` — optional Notion DB filter object
+
+Idempotent: pages whose `last_edited_time` matches the local file's
+frontmatter are skipped, so re-running is cheap and safe.
+
+Returns `{vault_name, vault_path, database_id, imported_count,
+imported_files, skipped_count, skipped_files, errors}`. Surface the
+counts and any errors to the user. Each imported file lands at
+`<vault>/raw/notes/<slug>-<short_id>.md` with frontmatter recording
+`notion_id`, `notion_url`, `last_edited_time`, and `imported_at` so
+re-runs can detect changes.
+
+**After `ingest_from_notion` writes files, run `index_sync` to fold the
+new raw notes into the vault's search index** — the catch-all
+"sync after writes" rule applies.
 
 ## When the engine MCP isn't reachable
 

--- a/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
+++ b/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
@@ -1082,11 +1082,65 @@ If the section already exists (e.g., the `notion-research-db` skill wrote it dur
 
 This is the location the `mcbrain` skill checks when running a Notion-bridged ingest. Older vaults registered their DB in `wiki/notion-databases.md`; the ingest procedure falls back to that path if the CLAUDE.md section is empty, so both work.
 
-**8f — Commit (Git strategy only).** If backup strategy is git, **do not run git directly** — by this point the filesystem MCP is loaded and direct git calls can leave a stale `.git/index.lock` (see CLAUDE.md's `## Backup → How Claude handles git for this vault`). Instead, **present** the commit block to the user in a copy-paste fence and ask them to run it in their terminal:
+**8f — Capture the Notion integration token (one-time per machine).**
+
+The `mcbrain-engine` MCP's server-side ingest tool (`ingest_from_notion`)
+calls Notion's REST API directly from the user's host — page bodies go
+straight to disk without passing through the LLM context. That requires
+a Notion integration token, which is *separate* from the Claude-Notion
+connector the user may already have configured.
+
+**Skip this sub-step entirely if a token already exists** at the
+platform-resolved path below — the engine reuses one token for every
+Notion-enabled vault on the machine. To check, list the directory and
+look for `notion-token`:
+
+- macOS: `~/Library/Application Support/mcbrain/notion-token`
+- Windows: `%APPDATA%\mcbrain\notion-token`
+
+If the file is absent, walk the user through this:
+
+> "To copy your Notion pages directly to McBrain without sending their
+> contents through me first (faster, and your context window doesn't
+> fill up), I need a Notion **integration token**. One-time setup:
+>
+> 1. Open <https://www.notion.so/my-integrations> in your browser
+> 2. Click **+ New integration** → name it `mcbrain` → workspace =
+>    your workspace → submit
+> 3. On the integration's page, copy the **Internal Integration Secret**
+>    (starts with `secret_…` or `ntn_…`)
+> 4. Open your `<NOTION_DB_NAME>` Notion database → click the **`...`**
+>    menu top-right → **Connections** → **Add connections** → pick
+>    `mcbrain`. (Without this step the integration can't read the DB.)
+> 5. Paste the token here."
+
+When the user pastes the token, **write it to disk yourself** using the
+Write tool against the granted Application Support / `%APPDATA%\` mount
+(the same one already granted in Step 5 / 5.6 for the engine install):
+
+- macOS: `<application-support-mount>/mcbrain/notion-token`
+- Windows: `<appdata-mount>/mcbrain/notion-token`
+
+Single line, no surrounding quotes, no trailing newline beyond the
+token itself. **Do NOT echo the token back to the user in chat after
+they paste it** — treat it like a password. After writing, confirm only
+that "the token is saved at `<path>`."
+
+If the `mcbrain/` parent directory doesn't exist yet (first
+Notion-enabled vault on this machine), `mkdir -p` against the mount
+first — that's safe Bash usage per the FUSE-flush rule (mkdir is fine).
+
+**8g — Register in CLAUDE.md (continued from 8e).** Already done.
+
+**8h — Commit (Git strategy only).** If backup strategy is git, **do not run git directly** — by this point the filesystem MCP is loaded and direct git calls can leave a stale `.git/index.lock` (see CLAUDE.md's `## Backup → How Claude handles git for this vault`). Instead, **present** the commit block to the user in a copy-paste fence and ask them to run it in their terminal:
 
 ```bash
 cd VAULT_PATH && git add CLAUDE.md && git commit -m "register: notion companion DB <NOTION_DB_NAME>" && git push
 ```
+
+(The Notion token file is *not* in the vault and *not* in git — it
+lives under `~/Library/Application Support/mcbrain/` on macOS and
+`%APPDATA%\mcbrain\` on Windows, both per-machine config locations.)
 
 ---
 
@@ -1150,6 +1204,34 @@ and downloads the FastEmbed model. Tell the user:
 
 Surface the JSON output. The `legacy_layout_removed`, `rebuilt_for_mismatch`,
 and `claude_md_patched` flags make it visible what migrate actually did.
+
+### Enable Notion ingest (only if NOTION_DB_INTENT was yes-create or yes-existing)
+
+If Step 8b captured a Notion intent and Step 8f wrote a token, register
+this vault as Notion-enabled in the engine registry. Call the
+`mcbrain-engine` MCP's `enable_notion_for_vault` tool with:
+
+- `vault` = `MCP_NAME` (e.g. `mcbrain-ai-science`)
+- `database_id` = `NOTION_DB_ID` (captured in 8c or returned by 8d)
+
+Surface the JSON output. The returned `notion_enabled: true` and
+`notion_db_id` confirm the registry has been updated. From now on the
+user can ask Claude things like *"ingest the latest Notion pages into
+McBrain"* and the LLM will route that to `ingest_from_notion(vault=…)`,
+which copies pages directly to `<vault>/raw/notes/` without sending
+content through the chat context.
+
+If `enable_notion_for_vault` errors with *"vault is not registered"*,
+that means the migrate call above failed — fix migrate first.
+
+If it errors with *"Notion integration token not found"*, that means
+Step 8f's token write didn't land where expected. Re-check the path
+(macOS: `~/Library/Application Support/mcbrain/notion-token`,
+Windows: `%APPDATA%\mcbrain\notion-token`) and retry.
+
+If `NOTION_DB_INTENT` was `no` (skip), don't call this — the vault
+stays without Notion config, and `ingest_from_notion` will refuse to
+run against it (which is what we want).
 
 ### Recovery from first-launch timeout
 

--- a/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
+++ b/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
@@ -1082,7 +1082,16 @@ If the section already exists (e.g., the `notion-research-db` skill wrote it dur
 
 This is the location the `mcbrain` skill checks when running a Notion-bridged ingest. Older vaults registered their DB in `wiki/notion-databases.md`; the ingest procedure falls back to that path if the CLAUDE.md section is empty, so both work.
 
-**8f — Capture the Notion integration token (one-time per machine).**
+**8f — Install the Notion integration token (user runs this in Terminal — token NEVER passes through chat).**
+
+> ⛔ **Security rule for this sub-step.** A Notion integration token is a
+> bearer credential — equivalent to a password. **Do not** ask the user
+> to paste it into chat, do not echo it, do not store it as a setup
+> variable, do not write it via the Write tool. Anything pasted into
+> chat is sent to Anthropic's servers and lives in the user's
+> conversation log. The right pattern: the user writes the token to a
+> file themselves in their own Terminal / PowerShell, the SKILL only
+> verifies the file is in place. The SKILL never sees the token.
 
 The `mcbrain-engine` MCP's server-side ingest tool (`ingest_from_notion`)
 calls Notion's REST API directly from the user's host — page bodies go
@@ -1090,47 +1099,92 @@ straight to disk without passing through the LLM context. That requires
 a Notion integration token, which is *separate* from the Claude-Notion
 connector the user may already have configured.
 
-**Skip this sub-step entirely if a token already exists** at the
+**Skip this sub-step entirely if a token file already exists** at the
 platform-resolved path below — the engine reuses one token for every
-Notion-enabled vault on the machine. To check, list the directory and
-look for `notion-token`:
-
-- macOS: `~/Library/Application Support/mcbrain/notion-token`
-- Windows: `%APPDATA%\mcbrain\notion-token`
-
-If the file is absent, walk the user through this:
-
-> "To copy your Notion pages directly to McBrain without sending their
-> contents through me first (faster, and your context window doesn't
-> fill up), I need a Notion **integration token**. One-time setup:
->
-> 1. Open <https://www.notion.so/my-integrations> in your browser
-> 2. Click **+ New integration** → name it `mcbrain` → workspace =
->    your workspace → submit
-> 3. On the integration's page, copy the **Internal Integration Secret**
->    (starts with `secret_…` or `ntn_…`)
-> 4. Open your `<NOTION_DB_NAME>` Notion database → click the **`...`**
->    menu top-right → **Connections** → **Add connections** → pick
->    `mcbrain`. (Without this step the integration can't read the DB.)
-> 5. Paste the token here."
-
-When the user pastes the token, **write it to disk yourself** using the
-Write tool against the granted Application Support / `%APPDATA%\` mount
-(the same one already granted in Step 5 / 5.6 for the engine install):
+Notion-enabled vault on the machine. Check by listing the directory
+through the granted mount:
 
 - macOS: `<application-support-mount>/mcbrain/notion-token`
 - Windows: `<appdata-mount>/mcbrain/notion-token`
 
-Single line, no surrounding quotes, no trailing newline beyond the
-token itself. **Do NOT echo the token back to the user in chat after
-they paste it** — treat it like a password. After writing, confirm only
-that "the token is saved at `<path>`."
+If you see `notion-token` in the listing, skip to step **8g**.
 
-If the `mcbrain/` parent directory doesn't exist yet (first
-Notion-enabled vault on this machine), `mkdir -p` against the mount
-first — that's safe Bash usage per the FUSE-flush rule (mkdir is fine).
+If the file is absent, present this script to the user **as a copy-paste
+block** (don't run it from Cowork's Bash — it touches the host
+filesystem and reads from the host clipboard / TTY):
 
-**8g — Register in CLAUDE.md (continued from 8e).** Already done.
+> "I need a Notion **integration token** to copy your Notion pages
+> directly into McBrain — without sending them through me first.
+> Important: I should NOT see this token. You'll paste it into your
+> own Terminal where it stays on your machine.
+>
+> **One-time setup (about 90 seconds):**
+>
+> 1. Open <https://www.notion.so/my-integrations> in your browser
+> 2. Click **+ New integration** → name it `mcbrain` → workspace =
+>    your workspace → **Submit**
+> 3. On the integration's page, copy the **Internal Integration Secret**
+>    (starts with `secret_…` or `ntn_…`) to your clipboard
+> 4. Open your `<NOTION_DB_NAME>` Notion database → click the **`…`**
+>    menu top-right → **Connections** → **Add connections** → pick
+>    `mcbrain`. (Without this step the integration can't read the DB.)
+> 5. Run **one** of the blocks below in your Terminal / PowerShell.
+>    The token never appears on screen and never enters this chat."
+
+For **macOS / Linux** (Terminal), paste-from-clipboard variant — assumes
+the user copied the token to clipboard in step 3:
+
+```bash
+mkdir -p ~/Library/Application\ Support/mcbrain && \
+pbpaste > ~/Library/Application\ Support/mcbrain/notion-token && \
+chmod 600 ~/Library/Application\ Support/mcbrain/notion-token && \
+echo "token saved"
+```
+
+(On Linux, swap `pbpaste` for `xclip -selection clipboard -o` or
+`wl-paste`, and the path for `~/.config/mcbrain/notion-token`.)
+
+If the user prefers not to use the clipboard, the type-it-in variant —
+token is hidden because of `read -s`:
+
+```bash
+mkdir -p ~/Library/Application\ Support/mcbrain && \
+read -s -p "Paste token, press enter: " TOK && \
+printf '%s' "$TOK" > ~/Library/Application\ Support/mcbrain/notion-token && \
+unset TOK && \
+chmod 600 ~/Library/Application\ Support/mcbrain/notion-token && \
+echo "token saved"
+```
+
+For **Windows** (PowerShell):
+
+```powershell
+$dir = "$env:APPDATA\mcbrain"
+New-Item -ItemType Directory -Path $dir -Force | Out-Null
+$tok = Read-Host -AsSecureString "Paste token, press enter"
+$plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+    [Runtime.InteropServices.Marshal]::SecureStringToBSTR($tok))
+[IO.File]::WriteAllText("$dir\notion-token", $plain)
+Remove-Variable tok, plain
+"token saved"
+```
+
+After the user reports back ("token saved" or any confirmation), verify
+the file exists — but DO NOT read its contents:
+
+- Bash against the mount: `test -f <application-support-mount>/mcbrain/notion-token && echo present || echo missing`
+- Or just `ls -la <application-support-mount>/mcbrain/` and confirm `notion-token` is in the listing
+
+If the file is missing, ask the user to re-run the block from above. If
+present, continue to 8g — you're done with the token.
+
+**Never read the file's contents.** The engine reads it on demand at
+the path; you don't need to. If the user pastes the token by mistake,
+acknowledge that it's now in the conversation log and recommend they
+**rotate the token** (delete the integration at notion.so/my-integrations
+and create a new one) before continuing.
+
+**8g — Register in CLAUDE.md (continued from 8e).** Already done above.
 
 **8h — Commit (Git strategy only).** If backup strategy is git, **do not run git directly** — by this point the filesystem MCP is loaded and direct git calls can leave a stale `.git/index.lock` (see CLAUDE.md's `## Backup → How Claude handles git for this vault`). Instead, **present** the commit block to the user in a copy-paste fence and ask them to run it in their terminal:
 
@@ -1140,7 +1194,8 @@ cd VAULT_PATH && git add CLAUDE.md && git commit -m "register: notion companion 
 
 (The Notion token file is *not* in the vault and *not* in git — it
 lives under `~/Library/Application Support/mcbrain/` on macOS and
-`%APPDATA%\mcbrain\` on Windows, both per-machine config locations.)
+`%APPDATA%\mcbrain\` on Windows, both per-machine config locations
+outside any vault.)
 
 ---
 


### PR DESCRIPTION
Closes #12.

Adds three new MCP tools to `mcbrain-engine` so the engine can ingest Notion pages directly from the user's host — page bodies are written straight to `<vault>/raw/notes/` without ever transiting the LLM context. Replaces the wasteful round-trip where the Claude-Notion connector returned every page's body to Claude, which then wrote it to the vault filesystem MCP.

## New tools

| Tool | Purpose |
|---|---|
| `enable_notion_for_vault(vault, database_id)` | Marks a vault Notion-enabled in the registry. Required before ingest runs. |
| `disable_notion_for_vault(vault)` | Clears the registry flag. Token + imported markdown left alone. |
| `ingest_from_notion(vault, database_id?, page_ids?, filter?)` | The load-bearing tool. Drains the configured DB (or specific pages), converts blocks to markdown, writes files. Idempotent via `last_edited_time` frontmatter check. |

All three are registered on the existing `mcbrain-engine` MCP — no new server, no new process, no new install path beyond a one-time integration token file.

## Files

- **`mcp-server/notion.py`** (new, ~350 lines) — stdlib-only Notion REST client (urllib + json, no `requests` dep) plus block→markdown converter handling paragraph, headings 1–3, bulleted/numbered/todo lists with proper tight spacing, code, quote, callout, divider, image, equation, bookmark, and basic tables. Frontmatter helpers for idempotency. Token read from per-machine path.
- **`mcp-server/paths.py`** — adds `notion_token_path()` (sibling of `vaults.json` under user config: `~/Library/Application Support/mcbrain/notion-token` on macOS, `%APPDATA%\mcbrain\notion-token` on Windows).
- **`mcp-server/registry.py`** — extends `put_vault` to preserve `notion_*` fields across re-registration (migrate must not silently un-enable). Adds `set_notion_config(name, db_id|None)` with canonical id normalization and clear validation.
- **`mcp-server/mcbrain_engine.py`** — `ingest_from_notion_impl` + enable/disable impls, vault Notion-config guard, MCP `@tool` wrappers.
- **`skills/mcbrain-setup/SKILL.md`** — new Step 8f for token capture (walks user through `notion.so/my-integrations`, password-style handling — token is never echoed back). Renumbered old 8f → 8h. New Step 8.5 sub-step calls `enable_notion_for_vault` after `migrate` succeeds, only when `NOTION_DB_INTENT` was yes-*.
- **`skills/mcbrain-ops/SKILL.md`** — documents the three new tools, highlights `ingest_from_notion` as the token-cost win, reminds callers to run `index_sync` after ingest writes.
- **Versions** — `plugin.json` + `marketplace.json` bumped to 2.1.0 (feature add, no breaking changes).

## Auth: separate integration token

The Claude-Notion connector lives in Claude's plugin runtime and is not callable from other MCP servers. So the engine needs its own Notion API token (bearer, from notion.so/my-integrations). Both can coexist on the user's machine — each is the right fit for its workflow (LLM-mediated ad-hoc queries vs server-side bulk ingest).

The token lives in a file, **not** an environment variable, so:
- Cowork writes it via the Write tool against the already-granted `~/Library/Application Support/` mount (no JSON-editing fragility, no env-var-in-sandbox confusion)
- The engine reads it on demand from `paths.notion_token_path()`
- Per-machine — every Notion-enabled vault on the host shares one token

## Constraint per the issue

`ingest_from_notion` refuses to run unless the vault has `notion_enabled: True` in the registry. Error message points at `mcbrain-setup` Step 8 for first-time configuration, or `enable_notion_for_vault` for direct calls.

## Verified during development

- All Python files parse
- Markdown converter smoke-tested on representative blocks (headings, bold/italic, tight bulleted/numbered lists, code with language, quote, divider, todo)
- Registry round-trip: `put_vault` → enable → re-`put_vault` (preserves config) → disable → bad db_id rejection

## Not verified

- Live Notion API call against a real DB (no test token in dev session)
- End-to-end MCP wire layer (would need a running engine venv)
- Setup SKILL flow against a fresh vault in Cowork

These need a real-world smoke from the user.