### PR TITLE
Route Notion-bridged ingest to ingest_from_notion MCP tool, not the connector

### DIFF
--- a/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
+++ b/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
@@ -1024,7 +1024,7 @@ If Claude can read `CLAUDE.md`, the MCP is working. If not, troubleshoot:
 
 McBrain pairs nicely with a Notion research tracker: a database where the user queues research questions, the `notion-research-runner` skill drains the queue with parallel subagents and writes findings back to each task page, and then the Notion-bridged ingest mode (documented in CLAUDE.md) pulls those findings into `raw/notes/` and onward into the wiki. This step wires up that pairing at setup time so it's already configured the first time the user wants to use it.
 
-This step is **optional**. Skip cleanly if the user doesn't use Notion or doesn't want a tracker right now.
+**The whole step is optional, but its sub-steps are not.** If the user picks "Skip for now" in 8b, jump to Step 9 — done. **If the user picks "Use existing database" or "Create a new one" in 8b, you MUST execute every sub-step from 8c through 8f (and 8g if backup strategy is git) in order before continuing to Step 8.5.** In particular, **8f (the Notion integration token install) is required for the engine's `ingest_from_notion` tool to work** — skipping it leaves the user with the LLM-mediated fallback (every page body streamed through chat), which defeats the point of opting into Notion. Do not skip 8f because it looks long or because the user "already configured" Notion in chat — what matters is whether the token file is on disk.
 
 **8a — Check for a Notion MCP connector.** Enumerate available tools and look for ones that perform Notion operations. Match by *capability*, not exact name — many connectors exist (Anthropic's claude.ai Notion connector, Notion's official `@notionhq/notion-mcp-server`, community servers). The capabilities needed here are *search*, *create-database*, and *retrieve-database*; tool names typically contain `notion`, `search`, `database`, or fragments like `API-post-search` / `API-post-database`.
 
@@ -1082,8 +1082,16 @@ If the section already exists (e.g., the `notion-research-db` skill wrote it dur
 
 This is the location the `mcbrain` skill checks when running a Notion-bridged ingest. Older vaults registered their DB in `wiki/notion-databases.md`; the ingest procedure falls back to that path if the CLAUDE.md section is empty, so both work.
 
-**8f — Install the Notion integration token (user runs this in Terminal — token NEVER passes through chat).**
+**8f — Install the Notion integration token (REQUIRED if NOTION_DB_INTENT was yes-*).**
 
+> 🔴 **Do not skip this sub-step.** If the user opted into Notion in 8b
+> (yes-existing or yes-create), the engine's `ingest_from_notion` tool
+> needs a Notion integration token sitting in a file on the host. No
+> token = no server-side ingest = every page body streams through chat
+> on every future ingest. Skipping 8f means the user's "I want Notion"
+> answer in 8b is half-applied — they get the CLAUDE.md registration
+> (8e) but not the working ingest path. Always run 8f for these users.
+>
 > ⛔ **Security rule for this sub-step.** A Notion integration token is a
 > bearer credential — equivalent to a password. **Do not** ask the user
 > to paste it into chat, do not echo it, do not store it as a setup
@@ -1184,9 +1192,7 @@ acknowledge that it's now in the conversation log and recommend they
 **rotate the token** (delete the integration at notion.so/my-integrations
 and create a new one) before continuing.
 
-**8g — Register in CLAUDE.md (continued from 8e).** Already done above.
-
-**8h — Commit (Git strategy only).** If backup strategy is git, **do not run git directly** — by this point the filesystem MCP is loaded and direct git calls can leave a stale `.git/index.lock` (see CLAUDE.md's `## Backup → How Claude handles git for this vault`). Instead, **present** the commit block to the user in a copy-paste fence and ask them to run it in their terminal:
+**8g — Commit (Git strategy only).** If backup strategy is git, **do not run git directly** — by this point the filesystem MCP is loaded and direct git calls can leave a stale `.git/index.lock` (see CLAUDE.md's `## Backup → How Claude handles git for this vault`). Instead, **present** the commit block to the user in a copy-paste fence and ask them to run it in their terminal:
 
 ```bash
 cd VAULT_PATH && git add CLAUDE.md && git commit -m "register: notion companion DB <NOTION_DB_NAME>" && git push

--- a/plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md
+++ b/plugins/mcbrain/skills/mcbrain-setup/references/claude-md-template.md
@@ -123,27 +123,40 @@ Use when the user has just finished a `notion-research-runner` pass, or referenc
 
 **Hard rule: do not re-research.** Do not spawn research subagents, do not call `notion-research-runner`, do not run web search for the topic. The research is already done — your job is to file it, not redo it.
 
-1. **Find the companion DB.** Look in this CLAUDE.md's `## Notion companion databases` section first — that's the canonical registry, populated by `mcbrain-setup` (Step 8) and by `notion-research-db`. If that section is missing or empty, fall back to `wiki/notion-databases.md` (the legacy location used by older vaults). Capture the database URL / ID. If multiple trackers are registered for this vault, ask the user which one.
-2. **Pull completed task pages.** Query the tracker for rows with Status `In progress` whose page body contains a research run (look for the `## Summary` / `## Key Findings` / `## Sources` section headings the runner writes). If the user named specific tasks, use those instead. Skip rows whose Notion page ID already appears in the `sources:` frontmatter of any wiki page — those have already been ingested.
-3. **Copy to `raw/notes/` verbatim.** For each task, write the page body to `raw/notes/<slug>.md` (slug = lowercased, hyphenated task title). Prepend YAML frontmatter capturing provenance:
+**Hard rule: do not pull pages through chat when the engine can copy them server-side.** The `mcbrain-engine` MCP's `ingest_from_notion` tool calls Notion's REST API directly from the user's host and writes page bodies straight to `raw/notes/`. Page contents never enter the chat / LLM context — only summary counts come back. Use it whenever it's available; only fall back to the LLM-mediated `notion-fetch` path if the engine refuses (vault not Notion-enabled, no token on host) and the user can't fix that right now.
+
+1. **Server-side copy via the engine MCP.** Call:
+
+   ```
+   ingest_from_notion(vault=<this vault's name>)
+   ```
+
+   The engine drains the vault's registered Notion DB, converts each page's blocks to markdown, and writes one file per page to `raw/notes/<slug>-<short_id>.md` with frontmatter:
 
    ```yaml
    ---
-   source: notion-research-tracker
-   notion_url: <task page URL>
-   notion_page_id: <task page ID>
-   tracker: <tracker name>
-   task_title: <task name>
-   research_date: <date the runner wrote the page>
-   captured: YYYY-MM-DD
+   notion_id: <page id>
+   notion_url: <page URL>
+   last_edited_time: <ISO from Notion>
+   imported_at: <ISO when this run wrote the file>
    ---
    ```
 
-   Do not edit, summarize, or reformat the research output. Copy it as-is — `raw/` is immutable history.
-4. **Run the standard wiki-update steps** (steps 2–7 of *Ingest from raw/* above) against the new `raw/notes/<slug>.md` files. Cite them in wiki pages exactly the same way you'd cite any other raw source.
-5. **Close the loop in Notion.** After the wiki write succeeds, flip the Notion task's Status to `Done`. If the wiki write failed for a task, leave the Notion status at `In progress` and surface the error so the user can retry.
-6. Append to `wiki/log.md`: `## [YYYY-MM-DD] ingest (notion) | <tracker> — <N> tasks`.
-7. Call the `mcbrain-engine` MCP's `index_sync` tool against this vault so the new wiki page(s) are searchable immediately.
+   Idempotent: pages whose `last_edited_time` matches the local file are skipped. Surface `imported_count` and `skipped_count` to the user.
+
+2. **If the engine refused with "vault not configured for Notion ingest"**, tell the user the vault needs to be enabled and (with their confirmation) call `enable_notion_for_vault(vault=<name>, database_id=<NOTION_DB_ID>)` — the DB id is in this CLAUDE.md's `## Notion companion databases` section. Then retry step 1.
+
+3. **If the engine refused with "Notion integration token not found"**, walk the user through `mcbrain-setup` Step 8f (the Terminal-based token install) and retry step 1 once they confirm the file is in place. **Never** ask the user to paste the token in chat — it's a bearer credential.
+
+4. **Fallback (engine path genuinely unavailable).** Only if the engine MCP isn't loaded at all, warn the user *"Falling back to LLM-mediated Notion ingest — each page's body will pass through this chat."* Then look up the DB in this CLAUDE.md's `## Notion companion databases` section, query the tracker for rows with Status `In progress` whose page body contains the runner's `## Summary` / `## Key Findings` / `## Sources` headings, and write each page to `raw/notes/<slug>.md` with provenance frontmatter (`source: notion-research-tracker`, `notion_url`, `notion_page_id`, `tracker`, `task_title`, `research_date`, `captured`).
+
+5. **Run the standard wiki-update steps** (steps 2–7 of *Ingest from raw/* above) against the new `raw/notes/*.md` files. Skip files whose `notion_id` already appears in the `sources:` frontmatter of any wiki page — those have been ingested before. Cite them in wiki pages exactly the same way you'd cite any other raw source.
+
+6. **Close the loop in Notion.** After the wiki write succeeds for each task, flip the Notion task's Status to `Done` (one `notion-update-page` call per task — that small write does pass through the connector, but it's metadata, not content). If the wiki write failed for a task, leave the Notion status at `In progress` and surface the error so the user can retry.
+
+7. Append to `wiki/log.md`: `## [YYYY-MM-DD] ingest (notion) | <tracker> — <N> tasks`.
+
+8. Call the `mcbrain-engine` MCP's `index_sync` tool against this vault so the new wiki page(s) are searchable immediately.
 
 ### Query
 When asked a question against the wiki:

--- a/plugins/mcbrain/skills/mcbrain/SKILL.md
+++ b/plugins/mcbrain/skills/mcbrain/SKILL.md
@@ -85,7 +85,31 @@ Decide between these two modes after reading CLAUDE.md, **before** doing any wor
 - The user references "the Notion pages", "the research", "those tasks", "the tracker", or names a research tracker explicitly.
 - The user says something like "ingest the research" / "ingest from Notion" / "pull the Notion findings into the wiki".
 
-In this mode, the source pages live in Notion, not on disk. The first step is to copy them into `raw/` (typically `raw/notes/`), then run the standard ingest on the resulting files. **Hard rule: never spawn research subagents and never call `notion-research-runner` from this mode — the research is already done.** Follow the procedure documented in CLAUDE.md under `## Operations → Ingest from Notion research tracker`.
+In this mode, the source pages live in Notion, not on disk. The first step is to copy them into `raw/` (typically `raw/notes/`), then run the standard ingest on the resulting files. **Hard rule: never spawn research subagents and never call `notion-research-runner` from this mode — the research is already done.**
+
+### Use the server-side ingest tool — do NOT fetch pages through chat
+
+**Mandatory routing rule, overrides CLAUDE.md if it disagrees.** When you have Notion-bridged ingest work to do, **first attempt** the `mcbrain-engine` MCP's `ingest_from_notion` tool:
+
+```
+ingest_from_notion(vault=<this vault's name>)
+```
+
+That tool calls Notion's REST API directly from the user's host and writes page bodies straight to `<vault>/raw/notes/`. **Page contents do NOT pass through the chat / LLM context** — only summary counts come back. For any ingest of more than 2–3 pages this is dramatically cheaper in tokens, latency, and conversation-log exposure than the connector-based path.
+
+Three outcomes from that call:
+
+1. **Success** (`imported_count` ≥ 0, no auth/config errors). The pages are now in `raw/notes/` as markdown with frontmatter (`notion_id`, `notion_url`, `last_edited_time`, `imported_at`). Surface the imported / skipped counts to the user, then proceed to the **standard wiki-update steps** (steps 2–7 of *Ingest from raw/* in CLAUDE.md) against the new files. **Do not** also call `notion-fetch` / `notion-search` against those same pages — the ingest tool already pulled them.
+
+2. **Refused: vault not Notion-enabled.** Error message will say *"Vault X is not configured for Notion ingest. Run mcbrain-setup Step 8 to enable, or call enable_notion_for_vault(...)"*. Tell the user the vault needs to be enabled — give them the one-line MCP call:
+
+   > "This vault isn't configured for server-side Notion ingest yet. To enable, I'll need to call the engine's `enable_notion_for_vault` tool with the database ID. The DB is registered in your CLAUDE.md's `## Notion companion databases` section as `<NOTION_DB_ID>`. Want me to call it?"
+
+   On confirmation, call `enable_notion_for_vault(vault=<name>, database_id=<id>)`, then retry `ingest_from_notion`.
+
+3. **Refused: no Notion token on host.** Error mentions *"Notion integration token not found"*. Walk the user through `mcbrain-setup` Step 8f (the Terminal-based token install — never ask them to paste the token in chat). After they confirm the file is in place, retry `ingest_from_notion`.
+
+**Only fall back to the connector-based procedure** in CLAUDE.md (`notion-fetch` per page) if `ingest_from_notion` is genuinely unavailable — i.e. the engine MCP isn't loaded in this harness, or the user explicitly refuses to install a token. In that case warn the user *"Falling back to LLM-mediated Notion ingest. Each page's body will pass through this chat — slower and more token-expensive than the engine path."* before fetching anything.
 
 **Mode B — Standard ingest.** Use when there is no Notion context and the user says "ingest" with no source argument, or names a specific file already in `raw/`. Scan `raw/` for files that aren't yet referenced as a source in any `wiki/*.md` page, list them, and process per CLAUDE.md's `## Operations → Ingest from raw/` section.
 


### PR DESCRIPTION
After #13 shipped the server-side `ingest_from_notion` tool, the agent kept ingesting via Claude's Notion connector — streaming every page's body through the user's context window — because the `mcbrain` SKILL and CLAUDE.md template still described the old LLM-mediated procedure.

This PR points the agent at the engine tool first.

## Changes

**`skills/mcbrain/SKILL.md`** — under Mode A (Notion-bridged ingest), a new subsection "Use the server-side ingest tool — do NOT fetch pages through chat" with an explicit override of CLAUDE.md. Spells out the three outcomes from `ingest_from_notion`:
1. **Success** → proceed to wiki-update steps using the just-written `raw/notes/*.md` files.
2. **Refused: vault not Notion-enabled** → tell the user, offer to call `enable_notion_for_vault` with the DB id from CLAUDE.md's `## Notion companion databases` section, then retry.
3. **Refused: no token on host** → walk the user through `mcbrain-setup` Step 8f (Terminal install, never asks for the token in chat).

The connector path is now an explicit fallback, gated on the engine being genuinely unavailable, with a "this is the slow/expensive path" warning.

**`skills/mcbrain-setup/references/claude-md-template.md`** — "Ingest from Notion research tracker" rewritten with `ingest_from_notion` as step 1. New vaults get this baked in.

## Why both

The SKILL fix is the high-leverage one because SKILL files reload on every invocation. Existing vaults whose CLAUDE.md was written from the v2.0.0/v2.1.0 templates still have the old connector-based procedure in their CLAUDE.md, but the SKILL's "this overrides CLAUDE.md if it disagrees" rule catches them. So no vault re-patch is required for the fix to take effect — just a plugin refresh in Cowork.

The template fix is for net-new vaults so their CLAUDE.md matches the SKILL from day one.

## Behavior on the user's failure case

Before: agent enters Mode A → reads CLAUDE.md → calls `notion-fetch` per page → 16 page bodies stream through chat.

After: agent enters Mode A → SKILL's new subsection fires → `ingest_from_notion(vault=...)` → page bodies land in `raw/notes/` directly → agent only sees `imported_count: 16` in chat.