### PR TITLE
fix(setup): enumerate mcp-server/ instead of hardcoded file list

### DIFF
--- a/plugins/mcbrain/mcp-server/README.md
+++ b/plugins/mcbrain/mcp-server/README.md
@@ -28,10 +28,18 @@ the requirements. After first launch the runtime looks like:
 ├── mcbrain_engine.py     # the MCP server entry point
 ├── paths.py              # cross-platform path resolver (stdlib-only)
 ├── registry.py           # vault registry I/O
+├── notion.py             # Notion REST client + block-to-markdown converter (v2.1+)
 ├── schema.sql            # SQLite schema for <vault>/.mcbrain/index.db
 ├── requirements.txt      # mcp, fastembed, numpy
 └── venv/                 # created by launcher on first launch
 ```
+
+**Setup install rule.** The `mcbrain-setup` skill copies *every* top-level
+file from this directory (except this `README.md`) to `<runtime_root>/`.
+Don't maintain a hardcoded file list in the skill — adding a new module
+here (like `notion.py` in v2.1) should "just work" without a skill diff,
+provided the install procedure enumerates the directory rather than
+copying a fixed list.
 
 ## How the launcher works
 

--- a/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
+++ b/plugins/mcbrain/skills/mcbrain-setup/SKILL.md
@@ -891,26 +891,48 @@ Pick the right paths for `OS_TYPE`:
 > sometimes land; engine source files (~10–40 KB+) often don't. The
 > Write tool runs natively on the host and is the only reliable path.
 
-For each runtime source file:
+**Don't copy from a hardcoded file list — enumerate the plugin's
+`mcp-server/` directory and copy every file at its top level.** The
+plugin's runtime surface grows over time (e.g. `notion.py` was added
+in v2.1.0); a hardcoded list silently misses new modules and the
+engine fails at runtime with an `ImportError`. Instead:
 
-1. Read it from the plugin install with the **Read** tool:
-   - `${CLAUDE_PLUGIN_ROOT}/mcp-server/launcher.py`
-   - `${CLAUDE_PLUGIN_ROOT}/mcp-server/mcbrain_engine.py`
-   - `${CLAUDE_PLUGIN_ROOT}/mcp-server/paths.py`
-   - `${CLAUDE_PLUGIN_ROOT}/mcp-server/registry.py`
-   - `${CLAUDE_PLUGIN_ROOT}/mcp-server/schema.sql`
-   - `${CLAUDE_PLUGIN_ROOT}/mcp-server/requirements.txt`
-2. Write it to the destination with the **Write** tool — destination
-   path is `<application-support-mount>/mcbrain-engine/<filename>`.
+1. **List the source directory.** Run `ls
+   ${CLAUDE_PLUGIN_ROOT}/mcp-server/` (Bash on the plugin path is
+   safe — that's not a Cowork mount, it's the plugin install).
+   You should see a flat directory of files:
+   - `*.py` modules (`launcher.py`, `mcbrain_engine.py`, `paths.py`,
+     `registry.py`, `notion.py`, plus any future additions)
+   - `schema.sql`
+   - `requirements.txt`
+   - `README.md` (skip — runtime doesn't need it)
+   - **No subdirectories** at this level. If `ls` shows any other
+     subdir besides what's listed above, surface it to the user and
+     ask before copying.
+2. **For each `.py` file, plus `schema.sql` and `requirements.txt`**:
+   Read with the Read tool from `${CLAUDE_PLUGIN_ROOT}/mcp-server/<name>`,
+   write with the Write tool to
+   `<application-support-mount>/mcbrain-engine/<name>`. Skip
+   `README.md` — runtime doesn't need it.
 
 Creating the destination directory `<application-support-mount>/mcbrain-engine/`
 with Bash `mkdir -p` against the mount path is fine — `mkdir` is small
 and idempotent and doesn't trigger the FUSE flush problem. The danger
 is *file-content* writes, not directory creation.
 
-After all six files are written, verify with `ls -l` on the mount and
-**check the byte sizes match the source files** (a 0-byte or
-truncated `mcbrain_engine.py` is the classic FUSE-flush failure mode).
+After all files are written, verify by **counting and size-matching
+against the source directory**:
+
+```bash
+ls -1 ${CLAUDE_PLUGIN_ROOT}/mcp-server/ | grep -vE '^(README\.md|venv|__pycache__)$' | sort
+ls -1 <application-support-mount>/mcbrain-engine/ | grep -vE '^(venv|__pycache__)$' | sort
+```
+
+The two listings should match exactly (same filenames, same count).
+Then `ls -l` both directories and **check the byte sizes match
+file-by-file** — a 0-byte or truncated `mcbrain_engine.py` is the
+classic FUSE-flush failure mode, and a missing file is the bug we
+saw with `notion.py` in v2.1.0 setups.
 If any size is wrong or any file is missing, re-run the Write for that
 file — do not try to "fix" it with Bash.
 


### PR DESCRIPTION
## Bug

When v2.1.0 added `notion.py` to `plugins/mcbrain/mcp-server/`, Step 5.6's hardcoded copy list still enumerated only six files (`launcher.py`, `mcbrain_engine.py`, `paths.py`, `registry.py`, `schema.sql`, `requirements.txt`). Fresh setups silently shipped without `notion.py`. The engine ImportError'd at first ingest. The agent recovered by improvising — writing `notion.py` to `~/Documents/` and giving the user a `cp` command — but the user's confidence took a hit.

Reproducible across fresh installs: every new vault using `/mcbrain-setup` would skip `notion.py` unless the user noticed and asked.

## Fix

Two structural changes so the next module added to `mcp-server/` doesn't trigger the same dance:

1. **Step 5.6 enumerates the source directory** instead of reading from a fixed list. The SKILL now `ls`'s `${CLAUDE_PLUGIN_ROOT}/mcp-server/` and copies every top-level file (except `README.md`). Adding `slack.py` / `gdrive.py` / etc. in the future requires zero SKILL change.

2. **Verification now does a name-match** between source and destination directories:

   ```bash
   ls -1 source | sort
   ls -1 dest | sort
   ```

   The two listings must match exactly. A missing file shows up immediately, not at first MCP call.

3. **`mcp-server/README.md`** updated: tree includes `notion.py`, plus a documented "Setup install rule" stating that the SKILL enumerates rather than hardcodes — so the contract is visible to anyone touching the engine layout.

## No version bump

SKILL fix, not a feature. Existing v2.1.0 installs that hit this need `notion.py` copied manually once (the agent's recovery flow already did that, so most users are good). Future fresh setups won't.